### PR TITLE
Build fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
     maven { url "https://maven.melanx.de/" }
     maven { url "https://cursemaven.com/" }
     maven { url "https://api.modrinth.com/maven"}
+    maven { url "https://maven.theillusivec4.top/" }
 }
 
 dependencies {
@@ -23,8 +24,8 @@ dependencies {
     compileOnly fg.deobf("mezz.jei:jei-${jei_version}:api")
     runtimeOnly fg.deobf("mezz.jei:jei-${jei_version}")
 
-    curse.mod(3600023, curios_fileid as int)
-    curse.mod(245211, top_fileid as int)
-    curse.mod(324717, jade_fileid as int)
+    implementation fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
+    implementation curse.mod(245211, top_fileid as int)
+    implementation curse.mod(324717, jade_fileid as int)
     implementation fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,9 @@ license_name=MIT License
 license_url=https://opensource.org/licenses/MIT
 
 # Mod Dependendies
-libx_version=1.18.2-3.2.10
+libx_version=1.18.2-3.2.11
 jei_version=1.18.2:9.7.0.192
-curios_fileid=3748873
+curios_version=1.18.2-5.0.7.0
 top_fileid=3671753
 jade_fileid=3681449
 patchouli_version=1.18.2-67


### PR DESCRIPTION
  * Delete empty `accesstransformer.cfg`
  * Fix that curse dependencies were not applied due to a missing `implementation` before the `curse.mod`
  * Use the curios maven instead of getting curios from CurseMaven