### PR TITLE
1.18: Cleanup code base and fix the Lava Bucket Crash

### DIFF
--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/WoodenUtilities.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/WoodenUtilities.java
@@ -1,11 +1,8 @@
 package io.github.moderngamingworlds_mods.woodenutilities;
 
-import io.github.moderngamingworlds_mods.woodenutilities.common.init.ModBlocks;
 import io.github.moderngamingworlds_mods.woodenutilities.common.init.ModItems;
 import io.github.noeppi_noeppi.libx.mod.registration.ModXRegistration;
 import io.github.noeppi_noeppi.libx.mod.registration.RegistrationBuilder;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fml.common.Mod;

--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/block/WoodenFurnaceBlock.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/block/WoodenFurnaceBlock.java
@@ -83,7 +83,6 @@ public class WoodenFurnaceBlock extends AbstractFurnaceBlock implements Register
 
             Direction direction = state.getValue(FACING);
             Direction.Axis direction$axis = direction.getAxis();
-            double d3 = 0.52D;
             double d4 = rand.nextDouble() * 0.6D - 0.3D;
             double d5 = direction$axis == Direction.Axis.X ? (double) direction.getStepX() * 0.52D : d4;
             double d6 = rand.nextDouble() * 6.0D / 16.0D;

--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/config/ModConfig.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/config/ModConfig.java
@@ -4,7 +4,6 @@ import io.github.noeppi_noeppi.libx.annotation.config.RegisterConfig;
 import io.github.noeppi_noeppi.libx.config.Config;
 import io.github.noeppi_noeppi.libx.config.Group;
 import io.github.noeppi_noeppi.libx.config.validator.DoubleRange;
-import io.github.noeppi_noeppi.libx.config.validator.FloatRange;
 import io.github.noeppi_noeppi.libx.config.validator.IntRange;
 
 @RegisterConfig

--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/config/ModConfig.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/config/ModConfig.java
@@ -28,9 +28,6 @@ public class ModConfig {
 
         @Config("The max temperature that the Wooden Bucket can hold until burns itself.")
         public static int maxTemperature = 1300;
-
-        @Config("Number of seconds that the player will be set on fire when the bucket burn itself.")
-        public static int fireTime = 5;
     }
 
     @Group

--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/datagen/ModTagGenerator.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/datagen/ModTagGenerator.java
@@ -5,7 +5,6 @@ import io.github.moderngamingworlds_mods.woodenutilities.common.init.ModItems;
 import io.github.moderngamingworlds_mods.woodenutilities.common.init.ModTags;
 import io.github.noeppi_noeppi.libx.annotation.data.Datagen;
 import io.github.noeppi_noeppi.libx.data.provider.CommonTagsProviderBase;
-import io.github.noeppi_noeppi.libx.mod.ModX;
 import net.minecraft.data.DataGenerator;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ExistingFileHelper;

--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/init/ModBlocks.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/init/ModBlocks.java
@@ -5,7 +5,6 @@ import io.github.moderngamingworlds_mods.woodenutilities.common.block.Woodcutter
 import io.github.moderngamingworlds_mods.woodenutilities.common.block.WoodenFurnaceBlock;
 import io.github.moderngamingworlds_mods.woodenutilities.common.block.WoodenTntBlock;
 import io.github.moderngamingworlds_mods.woodenutilities.common.block.entity.WoodenFurnaceBlockEntity;
-import io.github.noeppi_noeppi.libx.annotation.registration.RegName;
 import io.github.noeppi_noeppi.libx.annotation.registration.RegisterClass;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;

--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/init/ModTags.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/init/ModTags.java
@@ -3,7 +3,6 @@ package io.github.moderngamingworlds_mods.woodenutilities.common.init;
 import io.github.moderngamingworlds_mods.woodenutilities.WoodenUtilities;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.tags.Tag;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 

--- a/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/item/buckets/WoodenBucketItem.java
+++ b/src/main/java/io/github/moderngamingworlds_mods/woodenutilities/common/item/buckets/WoodenBucketItem.java
@@ -31,6 +31,7 @@ import net.minecraft.world.phys.HitResult;
 import javax.annotation.Nonnull;
 import java.util.function.Supplier;
 
+@SuppressWarnings("deprecation")
 public class WoodenBucketItem extends BucketItem {
 
     private boolean hasCooldown = false;
@@ -65,8 +66,8 @@ public class WoodenBucketItem extends BucketItem {
                         level.setBlock(entity.blockPosition(), this.getFluid().defaultFluidState().createLegacyBlock(), Block.UPDATE_ALL);
                     }
                     stack.shrink(1);
-                    player.setSecondsOnFire(ModConfig.WoodenBucket.fireTime);
-                    player.broadcastBreakEvent(InteractionHand.MAIN_HAND);
+                    //TODO: This is crashing the game. Needs investigation.
+                    //player.broadcastBreakEvent(InteractionHand.MAIN_HAND);
                     this.hasCooldown = false;
                 }
             }


### PR DESCRIPTION
## Done:

- Removed a lot of unused imports.
- Fix some codebase warnings.
- "Fix" the lava bucket crash on breaking.

## Changes:

Don't set the player on fire after the lava bucket is destroyed since the lava is placed below their feet. This makes the player catch on fire for being on lava. 
This also removes the `WoodenBucket::fireTime` config.