### PR TITLE
Fix missing textures for special wooden cauldrons and add water variants

### DIFF
--- a/src/main/java/com/moderngamingworld/woodenutilities/block/WoodenCauldronBlock.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/block/WoodenCauldronBlock.java
@@ -1,0 +1,46 @@
+package com.moderngamingworld.woodenutilities.block;
+
+import java.util.function.Supplier;
+import net.minecraft.core.BlockPos;
+import net.minecraft.stats.Stats;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.CauldronBlock;
+import net.minecraft.world.level.block.LayeredCauldronBlock;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class WoodenCauldronBlock extends CauldronBlock {
+    private final Supplier<? extends LayeredCauldronBlock> waterCauldron;
+
+    public WoodenCauldronBlock(BlockBehaviour.Properties properties, Supplier<? extends LayeredCauldronBlock> waterCauldron) {
+        super(properties);
+        this.waterCauldron = waterCauldron;
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
+        ItemStack itemStack = player.getItemInHand(hand);
+        if (itemStack.is(Items.WATER_BUCKET)) {
+            if (!level.isClientSide) {
+                if (!player.getAbilities().instabuild) {
+                    player.setItemInHand(hand, new ItemStack(Items.BUCKET));
+                }
+                BlockState filledState = waterCauldron.get().defaultBlockState()
+                    .setValue(LayeredCauldronBlock.LEVEL, 3);
+                level.setBlock(pos, filledState, 3);
+                level.gameEvent(GameEvent.FLUID_PLACE, pos);
+                player.awardStat(Stats.FILL_CAULDRON);
+                player.awardStat(Stats.ITEM_USED.get(Items.WATER_BUCKET));
+            }
+            return InteractionResult.sidedSuccess(level.isClientSide);
+        }
+        return super.use(state, level, pos, player, hand, hit);
+    }
+}

--- a/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
@@ -1,10 +1,13 @@
 package com.moderngamingworld.woodenutilities.registry;
 
 import com.moderngamingworld.woodenutilities.WoodenUtilities;
+import com.moderngamingworld.woodenutilities.block.WoodenCauldronBlock;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BarrelBlock;
-import net.minecraft.world.level.block.CauldronBlock;
+import net.minecraft.world.level.block.CauldronInteraction;
+import net.minecraft.world.level.block.LayeredCauldronBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -14,86 +17,206 @@ import net.minecraftforge.registries.RegistryObject;
 public final class ModBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, WoodenUtilities.MOD_ID);
 
+    public static final RegistryObject<Block> WOODEN_WATER_CAULDRON = BLOCKS.register("wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> WOODEN_CAULDRON = BLOCKS.register("wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> OAK_WOODEN_WATER_CAULDRON = BLOCKS.register("oak_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> OAK_WOODEN_CAULDRON = BLOCKS.register("oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), OAK_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> SPRUCE_WOODEN_WATER_CAULDRON = BLOCKS.register("spruce_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> SPRUCE_WOODEN_CAULDRON = BLOCKS.register("spruce_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), SPRUCE_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> BIRCH_WOODEN_WATER_CAULDRON = BLOCKS.register("birch_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> BIRCH_WOODEN_CAULDRON = BLOCKS.register("birch_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), BIRCH_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> JUNGLE_WOODEN_WATER_CAULDRON = BLOCKS.register("jungle_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> JUNGLE_WOODEN_CAULDRON = BLOCKS.register("jungle_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), JUNGLE_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> ACACIA_WOODEN_WATER_CAULDRON = BLOCKS.register("acacia_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> ACACIA_WOODEN_CAULDRON = BLOCKS.register("acacia_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ACACIA_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> DARK_OAK_WOODEN_WATER_CAULDRON = BLOCKS.register("dark_oak_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> DARK_OAK_WOODEN_CAULDRON = BLOCKS.register("dark_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), DARK_OAK_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> MANGROVE_WOODEN_WATER_CAULDRON = BLOCKS.register("mangrove_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> MANGROVE_WOODEN_CAULDRON = BLOCKS.register("mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), MANGROVE_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> CHERRY_WOODEN_WATER_CAULDRON = BLOCKS.register("cherry_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> CHERRY_WOODEN_CAULDRON = BLOCKS.register("cherry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), CHERRY_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> BAMBOO_WOODEN_WATER_CAULDRON = BLOCKS.register("bamboo_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> BAMBOO_WOODEN_CAULDRON = BLOCKS.register("bamboo_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), BAMBOO_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> CRIMSON_WOODEN_WATER_CAULDRON = BLOCKS.register("crimson_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> CRIMSON_WOODEN_CAULDRON = BLOCKS.register("crimson_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), CRIMSON_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> WARPED_WOODEN_WATER_CAULDRON = BLOCKS.register("warped_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> WARPED_WOODEN_CAULDRON = BLOCKS.register("warped_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), WARPED_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> TWILIGHT_OAK_WOODEN_WATER_CAULDRON = BLOCKS.register("twilight_oak_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> TWILIGHT_OAK_WOODEN_CAULDRON = BLOCKS.register("twilight_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), TWILIGHT_OAK_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> CANOPY_WOODEN_WATER_CAULDRON = BLOCKS.register("canopy_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> CANOPY_WOODEN_CAULDRON = BLOCKS.register("canopy_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), CANOPY_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> TWILIGHT_MANGROVE_WOODEN_WATER_CAULDRON = BLOCKS.register("twilight_mangrove_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> TWILIGHT_MANGROVE_WOODEN_CAULDRON = BLOCKS.register("twilight_mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), TWILIGHT_MANGROVE_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> DARK_WOODEN_WATER_CAULDRON = BLOCKS.register("dark_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> DARK_WOODEN_CAULDRON = BLOCKS.register("dark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), DARK_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> TIME_WOODEN_WATER_CAULDRON = BLOCKS.register("time_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> TIME_WOODEN_CAULDRON = BLOCKS.register("time_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), TIME_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> TRANSFORMATION_WOODEN_WATER_CAULDRON = BLOCKS.register("transformation_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> TRANSFORMATION_WOODEN_CAULDRON = BLOCKS.register("transformation_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), TRANSFORMATION_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> MINING_WOODEN_WATER_CAULDRON = BLOCKS.register("mining_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> MINING_WOODEN_CAULDRON = BLOCKS.register("mining_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), MINING_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> SORTING_WOODEN_WATER_CAULDRON = BLOCKS.register("sorting_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> SORTING_WOODEN_CAULDRON = BLOCKS.register("sorting_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), SORTING_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> TOWERWOOD_WOODEN_WATER_CAULDRON = BLOCKS.register("towerwood_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> TOWERWOOD_WOODEN_CAULDRON = BLOCKS.register("towerwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), TOWERWOOD_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> FIR_WOODEN_WATER_CAULDRON = BLOCKS.register("fir_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> FIR_WOODEN_CAULDRON = BLOCKS.register("fir_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), FIR_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> PINE_WOODEN_WATER_CAULDRON = BLOCKS.register("pine_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> PINE_WOODEN_CAULDRON = BLOCKS.register("pine_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), PINE_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> MAPLE_WOODEN_WATER_CAULDRON = BLOCKS.register("maple_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> MAPLE_WOODEN_CAULDRON = BLOCKS.register("maple_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), MAPLE_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> REDWOOD_WOODEN_WATER_CAULDRON = BLOCKS.register("redwood_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> REDWOOD_WOODEN_CAULDRON = BLOCKS.register("redwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), REDWOOD_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> MAHOGANY_WOODEN_WATER_CAULDRON = BLOCKS.register("mahogany_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> MAHOGANY_WOODEN_CAULDRON = BLOCKS.register("mahogany_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), MAHOGANY_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> JACARANDA_WOODEN_WATER_CAULDRON = BLOCKS.register("jacaranda_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> JACARANDA_WOODEN_CAULDRON = BLOCKS.register("jacaranda_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), JACARANDA_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> PALM_WOODEN_WATER_CAULDRON = BLOCKS.register("palm_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> PALM_WOODEN_CAULDRON = BLOCKS.register("palm_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), PALM_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> WILLOW_WOODEN_WATER_CAULDRON = BLOCKS.register("willow_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> WILLOW_WOODEN_CAULDRON = BLOCKS.register("willow_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), WILLOW_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> DEAD_WOODEN_WATER_CAULDRON = BLOCKS.register("dead_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> DEAD_WOODEN_CAULDRON = BLOCKS.register("dead_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), DEAD_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> MAGIC_WOODEN_WATER_CAULDRON = BLOCKS.register("magic_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> MAGIC_WOODEN_CAULDRON = BLOCKS.register("magic_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), MAGIC_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> UMBRAN_WOODEN_WATER_CAULDRON = BLOCKS.register("umbran_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> UMBRAN_WOODEN_CAULDRON = BLOCKS.register("umbran_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), UMBRAN_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> HELLBARK_WOODEN_WATER_CAULDRON = BLOCKS.register("hellbark_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> HELLBARK_WOODEN_CAULDRON = BLOCKS.register("hellbark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), HELLBARK_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> EMPYREAL_WOODEN_WATER_CAULDRON = BLOCKS.register("empyreal_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> EMPYREAL_WOODEN_CAULDRON = BLOCKS.register("empyreal_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), EMPYREAL_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> ROSEROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("roseroot_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> ROSEROOT_WOODEN_CAULDRON = BLOCKS.register("roseroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ROSEROOT_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> YAGROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("yagroot_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> YAGROOT_WOODEN_CAULDRON = BLOCKS.register("yagroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), YAGROOT_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> CRUDEROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("cruderoot_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> CRUDEROOT_WOODEN_CAULDRON = BLOCKS.register("cruderoot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), CRUDEROOT_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> CONBERRY_WOODEN_WATER_CAULDRON = BLOCKS.register("conberry_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> CONBERRY_WOODEN_CAULDRON = BLOCKS.register("conberry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), CONBERRY_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> SUNROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("sunroot_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> SUNROOT_WOODEN_CAULDRON = BLOCKS.register("sunroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), SUNROOT_WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> SKYROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("skyroot_wooden_water_cauldron",
+        () -> new LayeredCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON),
+            precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER));
     public static final RegistryObject<Block> SKYROOT_WOODEN_CAULDRON = BLOCKS.register("skyroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), SKYROOT_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> WOODEN_BARREL = BLOCKS.register("wooden_barrel",
         () -> new BarrelBlock(BlockBehaviour.Properties.copy(Blocks.BARREL)));
     public static final RegistryObject<Block> OAK_WOODEN_BARREL = BLOCKS.register("oak_wooden_barrel",

--- a/src/main/resources/assets/woodenutilities/blockstates/acacia_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/acacia_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/acacia_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/acacia_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/acacia_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/bamboo_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/bamboo_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/bamboo_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/bamboo_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/bamboo_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/birch_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/birch_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/birch_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/birch_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/birch_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/canopy_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/canopy_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/canopy_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/canopy_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/canopy_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/cherry_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/cherry_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/cherry_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/cherry_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/cherry_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/conberry_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/conberry_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/conberry_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/conberry_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/conberry_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/crimson_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/crimson_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/crimson_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/crimson_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/crimson_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/cruderoot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/cruderoot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/cruderoot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/cruderoot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/cruderoot_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/dark_oak_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/dark_oak_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/dark_oak_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/dark_oak_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/dark_oak_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/dark_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/dark_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/dark_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/dark_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/dark_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/dead_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/dead_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/dead_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/dead_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/dead_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/empyreal_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/empyreal_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/empyreal_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/empyreal_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/empyreal_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/fir_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/fir_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/fir_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/fir_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/fir_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/hellbark_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/hellbark_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/hellbark_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/hellbark_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/hellbark_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/jacaranda_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/jacaranda_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/jacaranda_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/jacaranda_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/jacaranda_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/jungle_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/jungle_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/jungle_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/jungle_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/jungle_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/magic_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/magic_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/magic_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/magic_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/magic_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/mahogany_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/mahogany_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/mahogany_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/mahogany_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/mahogany_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/mangrove_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/mangrove_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/mangrove_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/mangrove_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/maple_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/maple_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/maple_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/maple_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/maple_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/mining_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/mining_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/mining_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/mining_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/mining_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/oak_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/oak_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/oak_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/oak_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/oak_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/palm_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/palm_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/palm_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/palm_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/palm_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/pine_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/pine_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/pine_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/pine_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/pine_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/redwood_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/redwood_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/redwood_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/redwood_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/redwood_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/roseroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/roseroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/roseroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/roseroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/roseroot_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/skyroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/skyroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/skyroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/skyroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/skyroot_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/sorting_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/sorting_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/sorting_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/sorting_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/sorting_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/spruce_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/spruce_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/spruce_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/spruce_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/spruce_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/sunroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/sunroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/sunroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/sunroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/sunroot_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/time_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/time_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/time_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/time_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/time_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/towerwood_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/towerwood_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/towerwood_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/towerwood_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/towerwood_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/transformation_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/transformation_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/transformation_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/transformation_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/transformation_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/twilight_mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/twilight_mangrove_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/twilight_mangrove_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/twilight_mangrove_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/twilight_mangrove_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/twilight_oak_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/twilight_oak_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/twilight_oak_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/twilight_oak_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/twilight_oak_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/umbran_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/umbran_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/umbran_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/umbran_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/umbran_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/warped_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/warped_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/warped_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/warped_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/warped_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/willow_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/willow_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/willow_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/willow_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/willow_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/yagroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/yagroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/yagroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/yagroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/yagroot_wooden_water_cauldron_level3"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/bamboo_planks",
+    "side": "minecraft:block/bamboo_planks",
+    "top": "minecraft:block/bamboo_planks",
+    "bottom": "minecraft:block/bamboo_planks",
+    "inside": "minecraft:block/bamboo_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/bamboo_planks",
+    "side": "minecraft:block/bamboo_planks",
+    "top": "minecraft:block/bamboo_planks",
+    "bottom": "minecraft:block/bamboo_planks",
+    "inside": "minecraft:block/bamboo_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/bamboo_planks",
+    "side": "minecraft:block/bamboo_planks",
+    "top": "minecraft:block/bamboo_planks",
+    "bottom": "minecraft:block/bamboo_planks",
+    "inside": "minecraft:block/bamboo_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/canopy_planks",
-    "side": "twilightforest:block/canopy_planks",
-    "top": "twilightforest:block/canopy_planks",
-    "bottom": "twilightforest:block/canopy_planks",
-    "inside": "twilightforest:block/canopy_planks"
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/cherry_planks",
+    "side": "minecraft:block/cherry_planks",
+    "top": "minecraft:block/cherry_planks",
+    "bottom": "minecraft:block/cherry_planks",
+    "inside": "minecraft:block/cherry_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/cherry_planks",
+    "side": "minecraft:block/cherry_planks",
+    "top": "minecraft:block/cherry_planks",
+    "bottom": "minecraft:block/cherry_planks",
+    "inside": "minecraft:block/cherry_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/cherry_planks",
+    "side": "minecraft:block/cherry_planks",
+    "top": "minecraft:block/cherry_planks",
+    "bottom": "minecraft:block/cherry_planks",
+    "inside": "minecraft:block/cherry_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/conberry_planks",
+    "side": "deep_aether:block/conberry_planks",
+    "top": "deep_aether:block/conberry_planks",
+    "bottom": "deep_aether:block/conberry_planks",
+    "inside": "deep_aether:block/conberry_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/conberry_planks",
+    "side": "deep_aether:block/conberry_planks",
+    "top": "deep_aether:block/conberry_planks",
+    "bottom": "deep_aether:block/conberry_planks",
+    "inside": "deep_aether:block/conberry_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "deep_aether:block/conberry_planks",
+    "side": "deep_aether:block/conberry_planks",
+    "top": "deep_aether:block/conberry_planks",
+    "bottom": "deep_aether:block/conberry_planks",
+    "inside": "deep_aether:block/conberry_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/crimson_planks",
+    "side": "minecraft:block/crimson_planks",
+    "top": "minecraft:block/crimson_planks",
+    "bottom": "minecraft:block/crimson_planks",
+    "inside": "minecraft:block/crimson_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/crimson_planks",
+    "side": "minecraft:block/crimson_planks",
+    "top": "minecraft:block/crimson_planks",
+    "bottom": "minecraft:block/crimson_planks",
+    "inside": "minecraft:block/crimson_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/crimson_planks",
+    "side": "minecraft:block/crimson_planks",
+    "top": "minecraft:block/crimson_planks",
+    "bottom": "minecraft:block/crimson_planks",
+    "inside": "minecraft:block/crimson_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/cruderoot_planks",
+    "side": "deep_aether:block/cruderoot_planks",
+    "top": "deep_aether:block/cruderoot_planks",
+    "bottom": "deep_aether:block/cruderoot_planks",
+    "inside": "deep_aether:block/cruderoot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/cruderoot_planks",
+    "side": "deep_aether:block/cruderoot_planks",
+    "top": "deep_aether:block/cruderoot_planks",
+    "bottom": "deep_aether:block/cruderoot_planks",
+    "inside": "deep_aether:block/cruderoot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "deep_aether:block/cruderoot_planks",
+    "side": "deep_aether:block/cruderoot_planks",
+    "top": "deep_aether:block/cruderoot_planks",
+    "bottom": "deep_aether:block/cruderoot_planks",
+    "inside": "deep_aether:block/cruderoot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/dark_planks",
-    "side": "twilightforest:block/dark_planks",
-    "top": "twilightforest:block/dark_planks",
-    "bottom": "twilightforest:block/dark_planks",
-    "inside": "twilightforest:block/dark_planks"
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/dead_planks",
+    "side": "biomesoplenty:block/dead_planks",
+    "top": "biomesoplenty:block/dead_planks",
+    "bottom": "biomesoplenty:block/dead_planks",
+    "inside": "biomesoplenty:block/dead_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/dead_planks",
+    "side": "biomesoplenty:block/dead_planks",
+    "top": "biomesoplenty:block/dead_planks",
+    "bottom": "biomesoplenty:block/dead_planks",
+    "inside": "biomesoplenty:block/dead_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/dead_planks",
+    "side": "biomesoplenty:block/dead_planks",
+    "top": "biomesoplenty:block/dead_planks",
+    "bottom": "biomesoplenty:block/dead_planks",
+    "inside": "biomesoplenty:block/dead_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/empyreal_planks",
+    "side": "biomesoplenty:block/empyreal_planks",
+    "top": "biomesoplenty:block/empyreal_planks",
+    "bottom": "biomesoplenty:block/empyreal_planks",
+    "inside": "biomesoplenty:block/empyreal_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/empyreal_planks",
+    "side": "biomesoplenty:block/empyreal_planks",
+    "top": "biomesoplenty:block/empyreal_planks",
+    "bottom": "biomesoplenty:block/empyreal_planks",
+    "inside": "biomesoplenty:block/empyreal_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/empyreal_planks",
+    "side": "biomesoplenty:block/empyreal_planks",
+    "top": "biomesoplenty:block/empyreal_planks",
+    "bottom": "biomesoplenty:block/empyreal_planks",
+    "inside": "biomesoplenty:block/empyreal_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/fir_planks",
+    "side": "biomesoplenty:block/fir_planks",
+    "top": "biomesoplenty:block/fir_planks",
+    "bottom": "biomesoplenty:block/fir_planks",
+    "inside": "biomesoplenty:block/fir_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/fir_planks",
+    "side": "biomesoplenty:block/fir_planks",
+    "top": "biomesoplenty:block/fir_planks",
+    "bottom": "biomesoplenty:block/fir_planks",
+    "inside": "biomesoplenty:block/fir_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/fir_planks",
+    "side": "biomesoplenty:block/fir_planks",
+    "top": "biomesoplenty:block/fir_planks",
+    "bottom": "biomesoplenty:block/fir_planks",
+    "inside": "biomesoplenty:block/fir_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/hellbark_planks",
+    "side": "biomesoplenty:block/hellbark_planks",
+    "top": "biomesoplenty:block/hellbark_planks",
+    "bottom": "biomesoplenty:block/hellbark_planks",
+    "inside": "biomesoplenty:block/hellbark_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/hellbark_planks",
+    "side": "biomesoplenty:block/hellbark_planks",
+    "top": "biomesoplenty:block/hellbark_planks",
+    "bottom": "biomesoplenty:block/hellbark_planks",
+    "inside": "biomesoplenty:block/hellbark_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/hellbark_planks",
+    "side": "biomesoplenty:block/hellbark_planks",
+    "top": "biomesoplenty:block/hellbark_planks",
+    "bottom": "biomesoplenty:block/hellbark_planks",
+    "inside": "biomesoplenty:block/hellbark_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/jacaranda_planks",
+    "side": "biomesoplenty:block/jacaranda_planks",
+    "top": "biomesoplenty:block/jacaranda_planks",
+    "bottom": "biomesoplenty:block/jacaranda_planks",
+    "inside": "biomesoplenty:block/jacaranda_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/jacaranda_planks",
+    "side": "biomesoplenty:block/jacaranda_planks",
+    "top": "biomesoplenty:block/jacaranda_planks",
+    "bottom": "biomesoplenty:block/jacaranda_planks",
+    "inside": "biomesoplenty:block/jacaranda_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/jacaranda_planks",
+    "side": "biomesoplenty:block/jacaranda_planks",
+    "top": "biomesoplenty:block/jacaranda_planks",
+    "bottom": "biomesoplenty:block/jacaranda_planks",
+    "inside": "biomesoplenty:block/jacaranda_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/magic_planks",
+    "side": "biomesoplenty:block/magic_planks",
+    "top": "biomesoplenty:block/magic_planks",
+    "bottom": "biomesoplenty:block/magic_planks",
+    "inside": "biomesoplenty:block/magic_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/magic_planks",
+    "side": "biomesoplenty:block/magic_planks",
+    "top": "biomesoplenty:block/magic_planks",
+    "bottom": "biomesoplenty:block/magic_planks",
+    "inside": "biomesoplenty:block/magic_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/magic_planks",
+    "side": "biomesoplenty:block/magic_planks",
+    "top": "biomesoplenty:block/magic_planks",
+    "bottom": "biomesoplenty:block/magic_planks",
+    "inside": "biomesoplenty:block/magic_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/mahogany_planks",
+    "side": "biomesoplenty:block/mahogany_planks",
+    "top": "biomesoplenty:block/mahogany_planks",
+    "bottom": "biomesoplenty:block/mahogany_planks",
+    "inside": "biomesoplenty:block/mahogany_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/mahogany_planks",
+    "side": "biomesoplenty:block/mahogany_planks",
+    "top": "biomesoplenty:block/mahogany_planks",
+    "bottom": "biomesoplenty:block/mahogany_planks",
+    "inside": "biomesoplenty:block/mahogany_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/mahogany_planks",
+    "side": "biomesoplenty:block/mahogany_planks",
+    "top": "biomesoplenty:block/mahogany_planks",
+    "bottom": "biomesoplenty:block/mahogany_planks",
+    "inside": "biomesoplenty:block/mahogany_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/maple_planks",
+    "side": "biomesoplenty:block/maple_planks",
+    "top": "biomesoplenty:block/maple_planks",
+    "bottom": "biomesoplenty:block/maple_planks",
+    "inside": "biomesoplenty:block/maple_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/maple_planks",
+    "side": "biomesoplenty:block/maple_planks",
+    "top": "biomesoplenty:block/maple_planks",
+    "bottom": "biomesoplenty:block/maple_planks",
+    "inside": "biomesoplenty:block/maple_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/maple_planks",
+    "side": "biomesoplenty:block/maple_planks",
+    "top": "biomesoplenty:block/maple_planks",
+    "bottom": "biomesoplenty:block/maple_planks",
+    "inside": "biomesoplenty:block/maple_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/mining_planks",
-    "side": "twilightforest:block/mining_planks",
-    "top": "twilightforest:block/mining_planks",
-    "bottom": "twilightforest:block/mining_planks",
-    "inside": "twilightforest:block/mining_planks"
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/palm_planks",
+    "side": "biomesoplenty:block/palm_planks",
+    "top": "biomesoplenty:block/palm_planks",
+    "bottom": "biomesoplenty:block/palm_planks",
+    "inside": "biomesoplenty:block/palm_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/palm_planks",
+    "side": "biomesoplenty:block/palm_planks",
+    "top": "biomesoplenty:block/palm_planks",
+    "bottom": "biomesoplenty:block/palm_planks",
+    "inside": "biomesoplenty:block/palm_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/palm_planks",
+    "side": "biomesoplenty:block/palm_planks",
+    "top": "biomesoplenty:block/palm_planks",
+    "bottom": "biomesoplenty:block/palm_planks",
+    "inside": "biomesoplenty:block/palm_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/pine_planks",
+    "side": "biomesoplenty:block/pine_planks",
+    "top": "biomesoplenty:block/pine_planks",
+    "bottom": "biomesoplenty:block/pine_planks",
+    "inside": "biomesoplenty:block/pine_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/pine_planks",
+    "side": "biomesoplenty:block/pine_planks",
+    "top": "biomesoplenty:block/pine_planks",
+    "bottom": "biomesoplenty:block/pine_planks",
+    "inside": "biomesoplenty:block/pine_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/pine_planks",
+    "side": "biomesoplenty:block/pine_planks",
+    "top": "biomesoplenty:block/pine_planks",
+    "bottom": "biomesoplenty:block/pine_planks",
+    "inside": "biomesoplenty:block/pine_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/redwood_planks",
+    "side": "biomesoplenty:block/redwood_planks",
+    "top": "biomesoplenty:block/redwood_planks",
+    "bottom": "biomesoplenty:block/redwood_planks",
+    "inside": "biomesoplenty:block/redwood_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/redwood_planks",
+    "side": "biomesoplenty:block/redwood_planks",
+    "top": "biomesoplenty:block/redwood_planks",
+    "bottom": "biomesoplenty:block/redwood_planks",
+    "inside": "biomesoplenty:block/redwood_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/redwood_planks",
+    "side": "biomesoplenty:block/redwood_planks",
+    "top": "biomesoplenty:block/redwood_planks",
+    "bottom": "biomesoplenty:block/redwood_planks",
+    "inside": "biomesoplenty:block/redwood_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/roseroot_planks",
+    "side": "deep_aether:block/roseroot_planks",
+    "top": "deep_aether:block/roseroot_planks",
+    "bottom": "deep_aether:block/roseroot_planks",
+    "inside": "deep_aether:block/roseroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/roseroot_planks",
+    "side": "deep_aether:block/roseroot_planks",
+    "top": "deep_aether:block/roseroot_planks",
+    "bottom": "deep_aether:block/roseroot_planks",
+    "inside": "deep_aether:block/roseroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "deep_aether:block/roseroot_planks",
+    "side": "deep_aether:block/roseroot_planks",
+    "top": "deep_aether:block/roseroot_planks",
+    "bottom": "deep_aether:block/roseroot_planks",
+    "inside": "deep_aether:block/roseroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "aether:block/skyroot_planks",
-    "side": "aether:block/skyroot_planks",
-    "top": "aether:block/skyroot_planks",
-    "bottom": "aether:block/skyroot_planks",
-    "inside": "aether:block/skyroot_planks"
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/sorting_planks",
-    "side": "twilightforest:block/sorting_planks",
-    "top": "twilightforest:block/sorting_planks",
-    "bottom": "twilightforest:block/sorting_planks",
-    "inside": "twilightforest:block/sorting_planks"
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/sunroot_planks",
+    "side": "deep_aether:block/sunroot_planks",
+    "top": "deep_aether:block/sunroot_planks",
+    "bottom": "deep_aether:block/sunroot_planks",
+    "inside": "deep_aether:block/sunroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/sunroot_planks",
+    "side": "deep_aether:block/sunroot_planks",
+    "top": "deep_aether:block/sunroot_planks",
+    "bottom": "deep_aether:block/sunroot_planks",
+    "inside": "deep_aether:block/sunroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "deep_aether:block/sunroot_planks",
+    "side": "deep_aether:block/sunroot_planks",
+    "top": "deep_aether:block/sunroot_planks",
+    "bottom": "deep_aether:block/sunroot_planks",
+    "inside": "deep_aether:block/sunroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/time_planks",
-    "side": "twilightforest:block/time_planks",
-    "top": "twilightforest:block/time_planks",
-    "bottom": "twilightforest:block/time_planks",
-    "inside": "twilightforest:block/time_planks"
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/towerwood",
+    "side": "twilightforest:block/towerwood",
+    "top": "twilightforest:block/towerwood",
+    "bottom": "twilightforest:block/towerwood",
+    "inside": "twilightforest:block/towerwood"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/towerwood",
+    "side": "twilightforest:block/towerwood",
+    "top": "twilightforest:block/towerwood",
+    "bottom": "twilightforest:block/towerwood",
+    "inside": "twilightforest:block/towerwood"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "twilightforest:block/towerwood",
+    "side": "twilightforest:block/towerwood",
+    "top": "twilightforest:block/towerwood",
+    "bottom": "twilightforest:block/towerwood",
+    "inside": "twilightforest:block/towerwood"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/transformation_planks",
-    "side": "twilightforest:block/transformation_planks",
-    "top": "twilightforest:block/transformation_planks",
-    "bottom": "twilightforest:block/transformation_planks",
-    "inside": "twilightforest:block/transformation_planks"
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/mangrove_planks",
-    "side": "twilightforest:block/mangrove_planks",
-    "top": "twilightforest:block/mangrove_planks",
-    "bottom": "twilightforest:block/mangrove_planks",
-    "inside": "twilightforest:block/mangrove_planks"
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_cauldron.json
@@ -1,10 +1,10 @@
 {
   "parent": "minecraft:block/cauldron",
   "textures": {
-    "particle": "twilightforest:block/twilight_oak_planks",
-    "side": "twilightforest:block/twilight_oak_planks",
-    "top": "twilightforest:block/twilight_oak_planks",
-    "bottom": "twilightforest:block/twilight_oak_planks",
-    "inside": "twilightforest:block/twilight_oak_planks"
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/umbran_planks",
+    "side": "biomesoplenty:block/umbran_planks",
+    "top": "biomesoplenty:block/umbran_planks",
+    "bottom": "biomesoplenty:block/umbran_planks",
+    "inside": "biomesoplenty:block/umbran_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/umbran_planks",
+    "side": "biomesoplenty:block/umbran_planks",
+    "top": "biomesoplenty:block/umbran_planks",
+    "bottom": "biomesoplenty:block/umbran_planks",
+    "inside": "biomesoplenty:block/umbran_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/umbran_planks",
+    "side": "biomesoplenty:block/umbran_planks",
+    "top": "biomesoplenty:block/umbran_planks",
+    "bottom": "biomesoplenty:block/umbran_planks",
+    "inside": "biomesoplenty:block/umbran_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/warped_planks",
+    "side": "minecraft:block/warped_planks",
+    "top": "minecraft:block/warped_planks",
+    "bottom": "minecraft:block/warped_planks",
+    "inside": "minecraft:block/warped_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/warped_planks",
+    "side": "minecraft:block/warped_planks",
+    "top": "minecraft:block/warped_planks",
+    "bottom": "minecraft:block/warped_planks",
+    "inside": "minecraft:block/warped_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "minecraft:block/warped_planks",
+    "side": "minecraft:block/warped_planks",
+    "top": "minecraft:block/warped_planks",
+    "bottom": "minecraft:block/warped_planks",
+    "inside": "minecraft:block/warped_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/willow_planks",
+    "side": "biomesoplenty:block/willow_planks",
+    "top": "biomesoplenty:block/willow_planks",
+    "bottom": "biomesoplenty:block/willow_planks",
+    "inside": "biomesoplenty:block/willow_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/willow_planks",
+    "side": "biomesoplenty:block/willow_planks",
+    "top": "biomesoplenty:block/willow_planks",
+    "bottom": "biomesoplenty:block/willow_planks",
+    "inside": "biomesoplenty:block/willow_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "biomesoplenty:block/willow_planks",
+    "side": "biomesoplenty:block/willow_planks",
+    "top": "biomesoplenty:block/willow_planks",
+    "bottom": "biomesoplenty:block/willow_planks",
+    "inside": "biomesoplenty:block/willow_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/yagroot_planks",
+    "side": "deep_aether:block/yagroot_planks",
+    "top": "deep_aether:block/yagroot_planks",
+    "bottom": "deep_aether:block/yagroot_planks",
+    "inside": "deep_aether:block/yagroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/yagroot_planks",
+    "side": "deep_aether:block/yagroot_planks",
+    "top": "deep_aether:block/yagroot_planks",
+    "bottom": "deep_aether:block/yagroot_planks",
+    "inside": "deep_aether:block/yagroot_planks"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level3.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level3.json
@@ -1,0 +1,10 @@
+{
+  "parent": "minecraft:block/water_cauldron_level3",
+  "textures": {
+    "particle": "deep_aether:block/yagroot_planks",
+    "side": "deep_aether:block/yagroot_planks",
+    "top": "deep_aether:block/yagroot_planks",
+    "bottom": "deep_aether:block/yagroot_planks",
+    "inside": "deep_aether:block/yagroot_planks"
+  }
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/acacia_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/acacia_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:acacia_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/bamboo_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/bamboo_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:bamboo_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/birch_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/birch_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:birch_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/canopy_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/canopy_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:canopy_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/cherry_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/cherry_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:cherry_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/conberry_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/conberry_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:conberry_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/crimson_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/crimson_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:crimson_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/cruderoot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/cruderoot_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:cruderoot_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_oak_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_oak_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:dark_oak_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:dark_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/dead_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/dead_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:dead_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/empyreal_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/empyreal_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:empyreal_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/fir_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/fir_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:fir_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/hellbark_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/hellbark_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:hellbark_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/jacaranda_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/jacaranda_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:jacaranda_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/jungle_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/jungle_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:jungle_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/magic_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/magic_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:magic_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/mahogany_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/mahogany_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:mahogany_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/mangrove_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:mangrove_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/maple_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/maple_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:maple_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/mining_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/mining_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:mining_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/oak_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/oak_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:oak_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/palm_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/palm_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:palm_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/pine_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/pine_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:pine_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/redwood_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/redwood_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:redwood_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/roseroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/roseroot_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:roseroot_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/skyroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/skyroot_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:skyroot_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/sorting_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/sorting_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:sorting_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/spruce_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/spruce_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:spruce_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/sunroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/sunroot_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:sunroot_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/time_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/time_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:time_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/towerwood_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/towerwood_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:towerwood_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/transformation_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/transformation_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:transformation_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_mangrove_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:twilight_mangrove_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_oak_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_oak_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:twilight_oak_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/umbran_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/umbran_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:umbran_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/warped_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/warped_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:warped_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/willow_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/willow_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:willow_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/yagroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/yagroot_wooden_water_cauldron.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:yagroot_wooden_cauldron"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Fix black/purple missing textures on several mod-specific wooden cauldrons (Twilight Oak, Canopy, Twilight Mangrove, Dark, Time, Transformation, Mining, Sorting, Skyroot). 
- Provide filled (water) variants for wooden cauldrons so they behave and render like vanilla cauldrons when filled with a water bucket. 
- Ensure filled variants drop the original empty wooden cauldron item and render correctly across water levels.

### Description
- Add `WoodenCauldronBlock` (`src/main/java/.../block/WoodenCauldronBlock.java`) which overrides `use` to handle `Items.WATER_BUCKET`, replace the block with a `LayeredCauldronBlock` water variant at `LEVEL=3`, emit `GameEvent.FLUID_PLACE`, consume/replace the bucket, and award the appropriate stats. 
- Update `ModBlocks` (`src/main/java/.../registry/ModBlocks.java`) to register `LayeredCauldronBlock` water variants for each wooden cauldron and wire each `WoodenCauldronBlock` to its corresponding water supplier. 
- Replace problematic mod texture references for the listed Twilight/Aether variants with vanilla plank fallbacks in the cauldron models and apply the same fallbacks to all water-level models so filled variants render properly. 
- Add blockstate JSONs, three water-level model JSONs (`*_level1/2/3.json`) for many wood types, and loot table JSONs for all wooden water cauldron variants so filled blocks render and drop the correct empty cauldron item.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984035842f88333800f31798c9c4b6d)