### PR TITLE
Add JEI dependency support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,11 +130,10 @@ dependencies {
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
-    // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
-    // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
-    // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
-    // runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
+    // JEI integration
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
 
     // Example mod dependency using a mod jar from ./libs with a flat dir repository
     // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
@@ -158,6 +157,7 @@ tasks.named('processResources', ProcessResources).configure {
             mod_homepage: mod_homepage,
             mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
             mod_author: mod_author, mod_description: mod_description,
+            jei_version: jei_version,
     ]
     inputs.properties replaceProperties
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -25,3 +25,10 @@ mandatory=true
 versionRange="[${minecraft_version}]"
 ordering="NONE"
 side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="jei"
+mandatory=false
+versionRange="[${jei_version},)"
+ordering="AFTER"
+side="CLIENT"


### PR DESCRIPTION
### Motivation
- Enable optional JEI integration so the mod can compile against JEI APIs and run with JEI present on client environments.

### Description
- Add JEI compile-time and runtime artifacts to `dependencies` in `build.gradle` using `fg.deobf(...)` for proper remapping.
- Add `jei_version` to the `processResources` replacement properties so `${jei_version}` resolves in templated resources at build-time.
- Declare JEI as an optional, client-side dependency in `src/main/resources/META-INF/mods.toml` with `ordering="AFTER"` so JEI is detected but not required.

### Testing
- Ran `gradle -q help`, which loaded the Gradle configuration but failed dependency resolution for the Forge userdev artifact in this environment (expected failure here). 
- Attempted `./gradlew compileJava -q`, which could not be run in this environment because the project wrapper (`./gradlew`) is not present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984272deae4833385f9319bbd49f2c6)