### PR TITLE
Fix JEI artifact resolution by adding JEI Maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,11 @@ repositories {
     // Put repositories for dependencies here
     // ForgeGradle automatically adds the Forge maven and Maven Central for you
 
+    // JEI artifacts are published here.
+    maven {
+        url = 'https://maven.blamejared.com'
+    }
+
     // If you have mod jar dependencies in ./libs, you can declare them as a repository like so.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:flat_dir_resolver
     // flatDir {
@@ -130,11 +135,10 @@ dependencies {
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
-    // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
-    // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
-    // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
-    // runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
+    // JEI integration
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
 
     // Example mod dependency using a mod jar from ./libs with a flat dir repository
     // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
@@ -158,6 +162,7 @@ tasks.named('processResources', ProcessResources).configure {
             mod_homepage: mod_homepage,
             mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
             mod_author: mod_author, mod_description: mod_description,
+            jei_version: jei_version,
     ]
     inputs.properties replaceProperties
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -25,3 +25,10 @@ mandatory=true
 versionRange="[${minecraft_version}]"
 ordering="NONE"
 side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="jei"
+mandatory=false
+versionRange="[${jei_version},)"
+ordering="AFTER"
+side="CLIENT"


### PR DESCRIPTION
### Motivation
- Fix Gradle resolution failures for `mezz.jei:*` artifacts by declaring JEI's Maven repository so JEI dependencies added previously can be resolved at build time.
- Ensure `${jei_version}` is expanded in templated resources and declare JEI as an optional client-side dependency in `mods.toml` so JEI can be present but not required.

### Description
- Added JEI Maven repository `https://maven.blamejared.com` to the `repositories` block in `build.gradle`.
- Kept the JEI dependency coordinates using `fg.deobf(...)` (`compileOnly` for APIs and `runtimeOnly` for the full JEI artifact) so remapping remains correct.
- Added `jei_version` to the `processResources` `replaceProperties` map in `build.gradle` so `${jei_version}` is expanded in templated resources.
- Declared JEI as an optional client-side dependency in `src/main/resources/META-INF/mods.toml` with `ordering="AFTER"` and `mandatory=false`.

### Testing
- Ran `gradle compileJava --no-daemon`, which still failed in this environment due to unresolved Forge `userdev` (`net.minecraftforge:forge:1.20.1-47.4.+:userdev`), so full compilation could not complete.
- The previous JEI artifact not found error was addressed by adding the JEI repository; environment constraints prevented a complete build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984272deae4833385f9319bbd49f2c6)