### PR TITLE
Allow water bucket interaction on wooden cauldrons; add WaterCrucibleRecipe and JEI wiring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,11 @@ repositories {
     // Put repositories for dependencies here
     // ForgeGradle automatically adds the Forge maven and Maven Central for you
 
+    // JEI artifacts are published here.
+    maven {
+        url = 'https://maven.blamejared.com'
+    }
+
     // If you have mod jar dependencies in ./libs, you can declare them as a repository like so.
     // See https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:flat_dir_resolver
     // flatDir {
@@ -130,11 +135,10 @@ dependencies {
     // then special handling is done to allow a setup of a vanilla dependency without the use of an external repository.
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
-    // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
-    // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
-    // compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
-    // runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
+    // JEI integration
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")
 
     // Example mod dependency using a mod jar from ./libs with a flat dir repository
     // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
@@ -158,6 +162,7 @@ tasks.named('processResources', ProcessResources).configure {
             mod_homepage: mod_homepage,
             mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
             mod_author: mod_author, mod_description: mod_description,
+            jei_version: jei_version,
     ]
     inputs.properties replaceProperties
 

--- a/src/main/java/com/moderngamingworld/woodenutilities/WaterCrucibleRecipe.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/WaterCrucibleRecipe.java
@@ -1,0 +1,52 @@
+package com.moderngamingworld.woodenutilities;
+
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraftforge.registries.ForgeRegistries;
+
+public final class WaterCrucibleRecipe {
+    private final Ingredient ingredient;
+    private final ItemStack result;
+    private final ResourceLocation fluid;
+
+    private WaterCrucibleRecipe(Ingredient ingredient, ItemStack result, ResourceLocation fluid) {
+        this.ingredient = ingredient;
+        this.result = result;
+        this.fluid = fluid;
+    }
+
+    public static WaterCrucibleRecipe fromJson(JsonObject json) {
+        Ingredient ingredient = Ingredient.fromJson(GsonHelper.getAsJsonObject(json, "ingredient"));
+        ItemStack result = parseResult(GsonHelper.getAsJsonObject(json, "result"));
+
+        ResourceLocation fluid = WaterCrucibleRecipeManager.waterFluid();
+        if (json.has("fluid")) {
+            fluid = new ResourceLocation(GsonHelper.getAsString(json, "fluid"));
+        }
+
+        return new WaterCrucibleRecipe(ingredient, result, fluid);
+    }
+
+    private static ItemStack parseResult(JsonObject resultJson) {
+        String itemId = GsonHelper.getAsString(resultJson, "item");
+        int count = GsonHelper.getAsInt(resultJson, "count", 1);
+        Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemId));
+        if (item == null) {
+            throw new IllegalArgumentException("Unknown item id in water crucible result: " + itemId);
+        }
+
+        return new ItemStack(item, count);
+    }
+
+    public boolean matches(ItemStack stack, ResourceLocation fluid) {
+        return this.fluid.equals(fluid) && this.ingredient.test(stack);
+    }
+
+    public ItemStack getResult() {
+        return this.result.copy();
+    }
+}

--- a/src/main/java/com/moderngamingworld/woodenutilities/WoodenCauldronBlock.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/WoodenCauldronBlock.java
@@ -21,7 +21,9 @@ public class WoodenCauldronBlock extends CauldronBlock {
     @Override
     public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
         ItemStack heldItem = player.getItemInHand(hand);
-        if (heldItem.getItem() instanceof BucketItem && heldItem.getItem() != Items.BUCKET) {
+        if (heldItem.getItem() instanceof BucketItem
+            && heldItem.getItem() != Items.BUCKET
+            && heldItem.getItem() != Items.WATER_BUCKET) {
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
 

--- a/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
@@ -1,12 +1,11 @@
 package com.moderngamingworld.woodenutilities.registry;
 
+import com.moderngamingworld.woodenutilities.WoodenCauldronBlock;
 import com.moderngamingworld.woodenutilities.WoodenUtilities;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BarrelBlock;
-import net.minecraft.world.level.block.CauldronBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.block.cauldron.CauldronInteraction;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -16,85 +15,85 @@ public final class ModBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, WoodenUtilities.MOD_ID);
 
     public static final RegistryObject<Block> WOODEN_CAULDRON = BLOCKS.register("wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> OAK_WOODEN_CAULDRON = BLOCKS.register("oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SPRUCE_WOODEN_CAULDRON = BLOCKS.register("spruce_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> BIRCH_WOODEN_CAULDRON = BLOCKS.register("birch_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> JUNGLE_WOODEN_CAULDRON = BLOCKS.register("jungle_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> ACACIA_WOODEN_CAULDRON = BLOCKS.register("acacia_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> DARK_OAK_WOODEN_CAULDRON = BLOCKS.register("dark_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MANGROVE_WOODEN_CAULDRON = BLOCKS.register("mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CHERRY_WOODEN_CAULDRON = BLOCKS.register("cherry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> BAMBOO_WOODEN_CAULDRON = BLOCKS.register("bamboo_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CRIMSON_WOODEN_CAULDRON = BLOCKS.register("crimson_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> WARPED_WOODEN_CAULDRON = BLOCKS.register("warped_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TWILIGHT_OAK_WOODEN_CAULDRON = BLOCKS.register("twilight_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CANOPY_WOODEN_CAULDRON = BLOCKS.register("canopy_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TWILIGHT_MANGROVE_WOODEN_CAULDRON = BLOCKS.register("twilight_mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> DARK_WOODEN_CAULDRON = BLOCKS.register("dark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TIME_WOODEN_CAULDRON = BLOCKS.register("time_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TRANSFORMATION_WOODEN_CAULDRON = BLOCKS.register("transformation_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MINING_WOODEN_CAULDRON = BLOCKS.register("mining_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SORTING_WOODEN_CAULDRON = BLOCKS.register("sorting_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TOWERWOOD_WOODEN_CAULDRON = BLOCKS.register("towerwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> FIR_WOODEN_CAULDRON = BLOCKS.register("fir_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> PINE_WOODEN_CAULDRON = BLOCKS.register("pine_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MAPLE_WOODEN_CAULDRON = BLOCKS.register("maple_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> REDWOOD_WOODEN_CAULDRON = BLOCKS.register("redwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MAHOGANY_WOODEN_CAULDRON = BLOCKS.register("mahogany_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> JACARANDA_WOODEN_CAULDRON = BLOCKS.register("jacaranda_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> PALM_WOODEN_CAULDRON = BLOCKS.register("palm_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> WILLOW_WOODEN_CAULDRON = BLOCKS.register("willow_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> DEAD_WOODEN_CAULDRON = BLOCKS.register("dead_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MAGIC_WOODEN_CAULDRON = BLOCKS.register("magic_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> UMBRAN_WOODEN_CAULDRON = BLOCKS.register("umbran_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> HELLBARK_WOODEN_CAULDRON = BLOCKS.register("hellbark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> EMPYREAL_WOODEN_CAULDRON = BLOCKS.register("empyreal_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> ROSEROOT_WOODEN_CAULDRON = BLOCKS.register("roseroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> YAGROOT_WOODEN_CAULDRON = BLOCKS.register("yagroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CRUDEROOT_WOODEN_CAULDRON = BLOCKS.register("cruderoot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CONBERRY_WOODEN_CAULDRON = BLOCKS.register("conberry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SUNROOT_WOODEN_CAULDRON = BLOCKS.register("sunroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SKYROOT_WOODEN_CAULDRON = BLOCKS.register("skyroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> WOODEN_BARREL = BLOCKS.register("wooden_barrel",
         () -> new BarrelBlock(BlockBehaviour.Properties.copy(Blocks.BARREL)));
     public static final RegistryObject<Block> OAK_WOODEN_BARREL = BLOCKS.register("oak_wooden_barrel",

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -25,3 +25,10 @@ mandatory=true
 versionRange="[${minecraft_version}]"
 ordering="NONE"
 side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="jei"
+mandatory=false
+versionRange="[${jei_version},)"
+ordering="AFTER"
+side="CLIENT"


### PR DESCRIPTION
### Motivation
- Ensure wooden cauldrons use the custom block class so they aren't replaced by vanilla cauldrons and preserve custom `use(...)` behavior. 
- Provide the missing `WaterCrucibleRecipe` implementation referenced by the recipe manager so JSON recipes can be parsed and matched. 
- Restore the ability to fill wooden cauldrons with water buckets while still blocking other non-empty buckets that would trigger vanilla replacement behavior.

### Description
- Updated `ModBlocks` to register `WoodenCauldronBlock` for all wooden cauldron variants so the custom behavior is actually used (`src/main/java/.../registry/ModBlocks.java`).
- Added `WaterCrucibleRecipe` implementing JSON parsing of `ingredient`, `result.item` + optional `result.count`, and optional `fluid`, plus `matches(...)` and `getResult()` that returns a defensive copy (`src/main/java/.../WaterCrucibleRecipe.java`).
- Fixed bucket handling in `WoodenCauldronBlock#use(...)` to allow `Items.WATER_BUCKET` interactions while still intercepting other filled buckets (`src/main/java/.../WoodenCauldronBlock.java`).
- Wired optional JEI support by adding the JEI Maven repo and dependencies and exposing `jei_version` to resource processing, and added an optional client-side JEI dependency in `mods.toml` (`build.gradle`, `src/main/resources/META-INF/mods.toml`).

### Testing
- Attempted `gradle compileJava --no-daemon`; the build cannot complete in this environment due to Forge userdev dependency resolution failing on `net.minecraftforge:forge:1.20.1-47.4.+:userdev`, so full compilation could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984272deae4833385f9319bbd49f2c6)