### PR TITLE
Prevent wooden cauldrons from converting on bucket use

### DIFF
--- a/src/main/java/com/moderngamingworld/woodenutilities/WoodenCauldronBlock.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/WoodenCauldronBlock.java
@@ -21,9 +21,7 @@ public class WoodenCauldronBlock extends CauldronBlock {
     @Override
     public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
         ItemStack heldItem = player.getItemInHand(hand);
-        if (heldItem.getItem() instanceof BucketItem
-            && heldItem.getItem() != Items.BUCKET
-            && heldItem.getItem() != Items.WATER_BUCKET) {
+        if (heldItem.getItem() instanceof BucketItem && heldItem.getItem() != Items.BUCKET) {
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
 

--- a/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
@@ -1,10 +1,10 @@
 package com.moderngamingworld.woodenutilities.registry;
 
+import com.moderngamingworld.woodenutilities.WoodenCauldronBlock;
 import com.moderngamingworld.woodenutilities.WoodenUtilities;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BarrelBlock;
-import net.minecraft.world.level.block.CauldronBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -15,85 +15,85 @@ public final class ModBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, WoodenUtilities.MOD_ID);
 
     public static final RegistryObject<Block> WOODEN_CAULDRON = BLOCKS.register("wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> OAK_WOODEN_CAULDRON = BLOCKS.register("oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SPRUCE_WOODEN_CAULDRON = BLOCKS.register("spruce_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> BIRCH_WOODEN_CAULDRON = BLOCKS.register("birch_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> JUNGLE_WOODEN_CAULDRON = BLOCKS.register("jungle_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> ACACIA_WOODEN_CAULDRON = BLOCKS.register("acacia_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> DARK_OAK_WOODEN_CAULDRON = BLOCKS.register("dark_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MANGROVE_WOODEN_CAULDRON = BLOCKS.register("mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CHERRY_WOODEN_CAULDRON = BLOCKS.register("cherry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> BAMBOO_WOODEN_CAULDRON = BLOCKS.register("bamboo_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CRIMSON_WOODEN_CAULDRON = BLOCKS.register("crimson_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> WARPED_WOODEN_CAULDRON = BLOCKS.register("warped_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TWILIGHT_OAK_WOODEN_CAULDRON = BLOCKS.register("twilight_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CANOPY_WOODEN_CAULDRON = BLOCKS.register("canopy_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TWILIGHT_MANGROVE_WOODEN_CAULDRON = BLOCKS.register("twilight_mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> DARK_WOODEN_CAULDRON = BLOCKS.register("dark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TIME_WOODEN_CAULDRON = BLOCKS.register("time_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TRANSFORMATION_WOODEN_CAULDRON = BLOCKS.register("transformation_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MINING_WOODEN_CAULDRON = BLOCKS.register("mining_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SORTING_WOODEN_CAULDRON = BLOCKS.register("sorting_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> TOWERWOOD_WOODEN_CAULDRON = BLOCKS.register("towerwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> FIR_WOODEN_CAULDRON = BLOCKS.register("fir_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> PINE_WOODEN_CAULDRON = BLOCKS.register("pine_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MAPLE_WOODEN_CAULDRON = BLOCKS.register("maple_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> REDWOOD_WOODEN_CAULDRON = BLOCKS.register("redwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MAHOGANY_WOODEN_CAULDRON = BLOCKS.register("mahogany_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> JACARANDA_WOODEN_CAULDRON = BLOCKS.register("jacaranda_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> PALM_WOODEN_CAULDRON = BLOCKS.register("palm_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> WILLOW_WOODEN_CAULDRON = BLOCKS.register("willow_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> DEAD_WOODEN_CAULDRON = BLOCKS.register("dead_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> MAGIC_WOODEN_CAULDRON = BLOCKS.register("magic_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> UMBRAN_WOODEN_CAULDRON = BLOCKS.register("umbran_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> HELLBARK_WOODEN_CAULDRON = BLOCKS.register("hellbark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> EMPYREAL_WOODEN_CAULDRON = BLOCKS.register("empyreal_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> ROSEROOT_WOODEN_CAULDRON = BLOCKS.register("roseroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> YAGROOT_WOODEN_CAULDRON = BLOCKS.register("yagroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CRUDEROOT_WOODEN_CAULDRON = BLOCKS.register("cruderoot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> CONBERRY_WOODEN_CAULDRON = BLOCKS.register("conberry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SUNROOT_WOODEN_CAULDRON = BLOCKS.register("sunroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> SKYROOT_WOODEN_CAULDRON = BLOCKS.register("skyroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
     public static final RegistryObject<Block> WOODEN_BARREL = BLOCKS.register("wooden_barrel",
         () -> new BarrelBlock(BlockBehaviour.Properties.copy(Blocks.BARREL)));
     public static final RegistryObject<Block> OAK_WOODEN_BARREL = BLOCKS.register("oak_wooden_barrel",


### PR DESCRIPTION
### Motivation
- Wooden cauldrons were being converted to vanilla cauldrons when interacted with fluid buckets, so interaction handling must be overridden and applied to every wooden cauldron variant.

### Description
- Change `WoodenCauldronBlock#use` to short-circuit `BucketItem` interactions by returning `InteractionResult.sidedSuccess` for any `BucketItem` that is not an empty `Items.BUCKET` to stop bucket-driven conversion.  
- Register all wooden cauldron variants with `WoodenCauldronBlock` instead of `CauldronBlock` in `ModBlocks` so the custom interaction logic applies to every variant.  
- Add import of `WoodenCauldronBlock` in `ModBlocks` and update registrations to instantiate the custom block class.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876a1049f883338beaa7d80b078e8a)