### PR TITLE
Add wooden water cauldrons and restore water-bucket filling without converting to vanilla

### DIFF
--- a/src/main/java/com/moderngamingworld/woodenutilities/WoodenWaterCauldronBlock.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/WoodenWaterCauldronBlock.java
@@ -7,42 +7,38 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.ItemUtils;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.CauldronBlock;
+import net.minecraft.world.level.block.CauldronInteraction;
 import net.minecraft.world.level.block.LayeredCauldronBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.phys.BlockHitResult;
 
-public class WoodenCauldronBlock extends CauldronBlock {
-    private final Supplier<Block> waterCauldron;
+public class WoodenWaterCauldronBlock extends LayeredCauldronBlock {
+    private final Supplier<Block> emptyCauldron;
 
-    public WoodenCauldronBlock(BlockBehaviour.Properties properties, Supplier<Block> waterCauldron) {
-        super(properties);
-        this.waterCauldron = waterCauldron;
+    public WoodenWaterCauldronBlock(BlockBehaviour.Properties properties, Supplier<Block> emptyCauldron) {
+        super(properties, precipitation -> precipitation == Biome.Precipitation.RAIN, CauldronInteraction.WATER);
+        this.emptyCauldron = emptyCauldron;
     }
 
     @Override
     public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
         ItemStack heldItem = player.getItemInHand(hand);
-        if (heldItem.getItem() == Items.WATER_BUCKET) {
+        if (heldItem.getItem() == Items.BUCKET && state.getValue(LEVEL) == 3) {
             if (!level.isClientSide) {
-                if (!player.getAbilities().instabuild) {
-                    player.setItemInHand(hand, new ItemStack(Items.BUCKET));
-                }
-                BlockState filledState = waterCauldron.get().defaultBlockState().setValue(LayeredCauldronBlock.LEVEL, 3);
-                level.setBlockAndUpdate(pos, filledState);
-                level.playSound(null, pos, SoundEvents.BUCKET_EMPTY, SoundSource.BLOCKS, 1.0F, 1.0F);
-                level.gameEvent(GameEvent.BLOCK_CHANGE, pos, GameEvent.Context.of(player, filledState));
+                ItemStack filledBucket = ItemUtils.createFilledResult(heldItem, player, new ItemStack(Items.WATER_BUCKET));
+                player.setItemInHand(hand, filledBucket);
+                level.setBlockAndUpdate(pos, emptyCauldron.get().defaultBlockState());
+                level.playSound(null, pos, SoundEvents.BUCKET_FILL, SoundSource.BLOCKS, 1.0F, 1.0F);
+                level.gameEvent(player, GameEvent.FLUID_PICKUP, pos);
             }
-            return InteractionResult.sidedSuccess(level.isClientSide);
-        }
-        if (heldItem.getItem() instanceof BucketItem && heldItem.getItem() != Items.BUCKET) {
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
 

--- a/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
+++ b/src/main/java/com/moderngamingworld/woodenutilities/registry/ModBlocks.java
@@ -1,10 +1,11 @@
 package com.moderngamingworld.woodenutilities.registry;
 
+import com.moderngamingworld.woodenutilities.WoodenCauldronBlock;
 import com.moderngamingworld.woodenutilities.WoodenUtilities;
+import com.moderngamingworld.woodenutilities.WoodenWaterCauldronBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.BarrelBlock;
-import net.minecraft.world.level.block.CauldronBlock;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
@@ -14,86 +15,166 @@ import net.minecraftforge.registries.RegistryObject;
 public final class ModBlocks {
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, WoodenUtilities.MOD_ID);
 
+    public static final RegistryObject<Block> WOODEN_WATER_CAULDRON = BLOCKS.register("wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.WOODEN_CAULDRON));
     public static final RegistryObject<Block> WOODEN_CAULDRON = BLOCKS.register("wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.WOODEN_WATER_CAULDRON));
+    public static final RegistryObject<Block> OAK_WOODEN_WATER_CAULDRON = BLOCKS.register("oak_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.OAK_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> SPRUCE_WOODEN_WATER_CAULDRON = BLOCKS.register("spruce_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.SPRUCE_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> BIRCH_WOODEN_WATER_CAULDRON = BLOCKS.register("birch_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.BIRCH_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> JUNGLE_WOODEN_WATER_CAULDRON = BLOCKS.register("jungle_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.JUNGLE_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> ACACIA_WOODEN_WATER_CAULDRON = BLOCKS.register("acacia_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.ACACIA_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> DARK_OAK_WOODEN_WATER_CAULDRON = BLOCKS.register("dark_oak_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.DARK_OAK_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> MANGROVE_WOODEN_WATER_CAULDRON = BLOCKS.register("mangrove_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.MANGROVE_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> CHERRY_WOODEN_WATER_CAULDRON = BLOCKS.register("cherry_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.CHERRY_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> BAMBOO_WOODEN_WATER_CAULDRON = BLOCKS.register("bamboo_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.BAMBOO_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> CRIMSON_WOODEN_WATER_CAULDRON = BLOCKS.register("crimson_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.CRIMSON_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> WARPED_WOODEN_WATER_CAULDRON = BLOCKS.register("warped_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.WARPED_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> TWILIGHT_OAK_WOODEN_WATER_CAULDRON = BLOCKS.register("twilight_oak_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.TWILIGHT_OAK_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> CANOPY_WOODEN_WATER_CAULDRON = BLOCKS.register("canopy_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.CANOPY_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> TWILIGHT_MANGROVE_WOODEN_WATER_CAULDRON = BLOCKS.register("twilight_mangrove_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.TWILIGHT_MANGROVE_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> DARK_WOODEN_WATER_CAULDRON = BLOCKS.register("dark_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.DARK_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> TIME_WOODEN_WATER_CAULDRON = BLOCKS.register("time_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.TIME_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> TRANSFORMATION_WOODEN_WATER_CAULDRON = BLOCKS.register("transformation_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.TRANSFORMATION_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> MINING_WOODEN_WATER_CAULDRON = BLOCKS.register("mining_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.MINING_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> SORTING_WOODEN_WATER_CAULDRON = BLOCKS.register("sorting_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.SORTING_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> TOWERWOOD_WOODEN_WATER_CAULDRON = BLOCKS.register("towerwood_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.TOWERWOOD_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> FIR_WOODEN_WATER_CAULDRON = BLOCKS.register("fir_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.FIR_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> PINE_WOODEN_WATER_CAULDRON = BLOCKS.register("pine_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.PINE_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> MAPLE_WOODEN_WATER_CAULDRON = BLOCKS.register("maple_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.MAPLE_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> REDWOOD_WOODEN_WATER_CAULDRON = BLOCKS.register("redwood_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.REDWOOD_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> MAHOGANY_WOODEN_WATER_CAULDRON = BLOCKS.register("mahogany_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.MAHOGANY_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> JACARANDA_WOODEN_WATER_CAULDRON = BLOCKS.register("jacaranda_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.JACARANDA_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> PALM_WOODEN_WATER_CAULDRON = BLOCKS.register("palm_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.PALM_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> WILLOW_WOODEN_WATER_CAULDRON = BLOCKS.register("willow_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.WILLOW_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> DEAD_WOODEN_WATER_CAULDRON = BLOCKS.register("dead_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.DEAD_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> MAGIC_WOODEN_WATER_CAULDRON = BLOCKS.register("magic_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.MAGIC_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> UMBRAN_WOODEN_WATER_CAULDRON = BLOCKS.register("umbran_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.UMBRAN_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> HELLBARK_WOODEN_WATER_CAULDRON = BLOCKS.register("hellbark_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.HELLBARK_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> EMPYREAL_WOODEN_WATER_CAULDRON = BLOCKS.register("empyreal_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.EMPYREAL_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> ROSEROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("roseroot_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.ROSEROOT_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> YAGROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("yagroot_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.YAGROOT_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> CRUDEROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("cruderoot_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.CRUDEROOT_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> CONBERRY_WOODEN_WATER_CAULDRON = BLOCKS.register("conberry_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.CONBERRY_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> SUNROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("sunroot_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.SUNROOT_WOODEN_CAULDRON));
+    public static final RegistryObject<Block> SKYROOT_WOODEN_WATER_CAULDRON = BLOCKS.register("skyroot_wooden_water_cauldron",
+        () -> new WoodenWaterCauldronBlock(BlockBehaviour.Properties.copy(Blocks.WATER_CAULDRON), ModBlocks.SKYROOT_WOODEN_CAULDRON));
     public static final RegistryObject<Block> OAK_WOODEN_CAULDRON = BLOCKS.register("oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.OAK_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> SPRUCE_WOODEN_CAULDRON = BLOCKS.register("spruce_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.SPRUCE_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> BIRCH_WOODEN_CAULDRON = BLOCKS.register("birch_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.BIRCH_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> JUNGLE_WOODEN_CAULDRON = BLOCKS.register("jungle_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.JUNGLE_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> ACACIA_WOODEN_CAULDRON = BLOCKS.register("acacia_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.ACACIA_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> DARK_OAK_WOODEN_CAULDRON = BLOCKS.register("dark_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.DARK_OAK_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> MANGROVE_WOODEN_CAULDRON = BLOCKS.register("mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.MANGROVE_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> CHERRY_WOODEN_CAULDRON = BLOCKS.register("cherry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.CHERRY_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> BAMBOO_WOODEN_CAULDRON = BLOCKS.register("bamboo_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.BAMBOO_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> CRIMSON_WOODEN_CAULDRON = BLOCKS.register("crimson_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.CRIMSON_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> WARPED_WOODEN_CAULDRON = BLOCKS.register("warped_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.WARPED_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> TWILIGHT_OAK_WOODEN_CAULDRON = BLOCKS.register("twilight_oak_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.TWILIGHT_OAK_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> CANOPY_WOODEN_CAULDRON = BLOCKS.register("canopy_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.CANOPY_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> TWILIGHT_MANGROVE_WOODEN_CAULDRON = BLOCKS.register("twilight_mangrove_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.TWILIGHT_MANGROVE_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> DARK_WOODEN_CAULDRON = BLOCKS.register("dark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.DARK_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> TIME_WOODEN_CAULDRON = BLOCKS.register("time_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.TIME_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> TRANSFORMATION_WOODEN_CAULDRON = BLOCKS.register("transformation_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.TRANSFORMATION_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> MINING_WOODEN_CAULDRON = BLOCKS.register("mining_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.MINING_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> SORTING_WOODEN_CAULDRON = BLOCKS.register("sorting_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.SORTING_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> TOWERWOOD_WOODEN_CAULDRON = BLOCKS.register("towerwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.TOWERWOOD_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> FIR_WOODEN_CAULDRON = BLOCKS.register("fir_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.FIR_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> PINE_WOODEN_CAULDRON = BLOCKS.register("pine_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.PINE_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> MAPLE_WOODEN_CAULDRON = BLOCKS.register("maple_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.MAPLE_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> REDWOOD_WOODEN_CAULDRON = BLOCKS.register("redwood_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.REDWOOD_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> MAHOGANY_WOODEN_CAULDRON = BLOCKS.register("mahogany_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.MAHOGANY_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> JACARANDA_WOODEN_CAULDRON = BLOCKS.register("jacaranda_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.JACARANDA_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> PALM_WOODEN_CAULDRON = BLOCKS.register("palm_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.PALM_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> WILLOW_WOODEN_CAULDRON = BLOCKS.register("willow_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.WILLOW_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> DEAD_WOODEN_CAULDRON = BLOCKS.register("dead_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.DEAD_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> MAGIC_WOODEN_CAULDRON = BLOCKS.register("magic_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.MAGIC_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> UMBRAN_WOODEN_CAULDRON = BLOCKS.register("umbran_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.UMBRAN_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> HELLBARK_WOODEN_CAULDRON = BLOCKS.register("hellbark_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.HELLBARK_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> EMPYREAL_WOODEN_CAULDRON = BLOCKS.register("empyreal_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.EMPYREAL_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> ROSEROOT_WOODEN_CAULDRON = BLOCKS.register("roseroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.ROSEROOT_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> YAGROOT_WOODEN_CAULDRON = BLOCKS.register("yagroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.YAGROOT_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> CRUDEROOT_WOODEN_CAULDRON = BLOCKS.register("cruderoot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.CRUDEROOT_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> CONBERRY_WOODEN_CAULDRON = BLOCKS.register("conberry_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.CONBERRY_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> SUNROOT_WOODEN_CAULDRON = BLOCKS.register("sunroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.SUNROOT_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> SKYROOT_WOODEN_CAULDRON = BLOCKS.register("skyroot_wooden_cauldron",
-        () -> new CauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON)));
+        () -> new WoodenCauldronBlock(BlockBehaviour.Properties.copy(Blocks.CAULDRON), ModBlocks.SKYROOT_WOODEN_WATER_CAULDRON));
     public static final RegistryObject<Block> WOODEN_BARREL = BLOCKS.register("wooden_barrel",
         () -> new BarrelBlock(BlockBehaviour.Properties.copy(Blocks.BARREL)));
     public static final RegistryObject<Block> OAK_WOODEN_BARREL = BLOCKS.register("oak_wooden_barrel",

--- a/src/main/resources/assets/woodenutilities/blockstates/acacia_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/acacia_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/acacia_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/acacia_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/acacia_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/bamboo_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/bamboo_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/bamboo_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/bamboo_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/bamboo_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/birch_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/birch_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/birch_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/birch_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/birch_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/canopy_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/canopy_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/canopy_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/canopy_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/canopy_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/cherry_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/cherry_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/cherry_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/cherry_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/cherry_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/conberry_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/conberry_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/conberry_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/conberry_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/conberry_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/crimson_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/crimson_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/crimson_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/crimson_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/crimson_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/cruderoot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/cruderoot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/cruderoot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/cruderoot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/cruderoot_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/dark_oak_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/dark_oak_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/dark_oak_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/dark_oak_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/dark_oak_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/dark_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/dark_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/dark_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/dark_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/dark_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/dead_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/dead_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/dead_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/dead_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/dead_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/empyreal_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/empyreal_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/empyreal_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/empyreal_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/empyreal_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/fir_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/fir_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/fir_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/fir_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/fir_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/hellbark_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/hellbark_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/hellbark_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/hellbark_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/hellbark_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/jacaranda_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/jacaranda_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/jacaranda_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/jacaranda_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/jacaranda_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/jungle_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/jungle_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/jungle_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/jungle_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/jungle_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/magic_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/magic_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/magic_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/magic_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/magic_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/mahogany_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/mahogany_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/mahogany_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/mahogany_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/mahogany_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/mangrove_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/mangrove_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/mangrove_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/mangrove_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/maple_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/maple_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/maple_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/maple_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/maple_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/mining_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/mining_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/mining_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/mining_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/mining_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/oak_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/oak_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/oak_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/oak_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/oak_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/palm_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/palm_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/palm_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/palm_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/palm_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/pine_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/pine_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/pine_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/pine_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/pine_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/redwood_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/redwood_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/redwood_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/redwood_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/redwood_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/roseroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/roseroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/roseroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/roseroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/roseroot_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/skyroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/skyroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/skyroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/skyroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/skyroot_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/sorting_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/sorting_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/sorting_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/sorting_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/sorting_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/spruce_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/spruce_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/spruce_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/spruce_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/spruce_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/sunroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/sunroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/sunroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/sunroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/sunroot_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/time_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/time_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/time_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/time_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/time_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/towerwood_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/towerwood_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/towerwood_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/towerwood_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/towerwood_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/transformation_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/transformation_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/transformation_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/transformation_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/transformation_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/twilight_mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/twilight_mangrove_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/twilight_mangrove_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/twilight_mangrove_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/twilight_mangrove_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/twilight_oak_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/twilight_oak_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/twilight_oak_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/twilight_oak_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/twilight_oak_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/umbran_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/umbran_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/umbran_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/umbran_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/umbran_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/warped_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/warped_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/warped_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/warped_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/warped_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/willow_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/willow_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/willow_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/willow_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/willow_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/blockstates/yagroot_wooden_water_cauldron.json
+++ b/src/main/resources/assets/woodenutilities/blockstates/yagroot_wooden_water_cauldron.json
@@ -1,0 +1,13 @@
+{
+  "variants": {
+    "level=1": {
+      "model": "woodenutilities:block/yagroot_wooden_water_cauldron_level1"
+    },
+    "level=2": {
+      "model": "woodenutilities:block/yagroot_wooden_water_cauldron_level2"
+    },
+    "level=3": {
+      "model": "woodenutilities:block/yagroot_wooden_water_cauldron_full"
+    }
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/acacia_planks",
+    "side": "minecraft:block/acacia_planks",
+    "top": "minecraft:block/acacia_planks",
+    "bottom": "minecraft:block/acacia_planks",
+    "inside": "minecraft:block/acacia_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/bamboo_planks",
+    "side": "minecraft:block/bamboo_planks",
+    "top": "minecraft:block/bamboo_planks",
+    "bottom": "minecraft:block/bamboo_planks",
+    "inside": "minecraft:block/bamboo_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/bamboo_planks",
+    "side": "minecraft:block/bamboo_planks",
+    "top": "minecraft:block/bamboo_planks",
+    "bottom": "minecraft:block/bamboo_planks",
+    "inside": "minecraft:block/bamboo_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/bamboo_planks",
+    "side": "minecraft:block/bamboo_planks",
+    "top": "minecraft:block/bamboo_planks",
+    "bottom": "minecraft:block/bamboo_planks",
+    "inside": "minecraft:block/bamboo_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/birch_planks",
+    "side": "minecraft:block/birch_planks",
+    "top": "minecraft:block/birch_planks",
+    "bottom": "minecraft:block/birch_planks",
+    "inside": "minecraft:block/birch_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/canopy_planks",
+    "side": "twilightforest:block/canopy_planks",
+    "top": "twilightforest:block/canopy_planks",
+    "bottom": "twilightforest:block/canopy_planks",
+    "inside": "twilightforest:block/canopy_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/canopy_planks",
+    "side": "twilightforest:block/canopy_planks",
+    "top": "twilightforest:block/canopy_planks",
+    "bottom": "twilightforest:block/canopy_planks",
+    "inside": "twilightforest:block/canopy_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/canopy_planks",
+    "side": "twilightforest:block/canopy_planks",
+    "top": "twilightforest:block/canopy_planks",
+    "bottom": "twilightforest:block/canopy_planks",
+    "inside": "twilightforest:block/canopy_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/cherry_planks",
+    "side": "minecraft:block/cherry_planks",
+    "top": "minecraft:block/cherry_planks",
+    "bottom": "minecraft:block/cherry_planks",
+    "inside": "minecraft:block/cherry_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/cherry_planks",
+    "side": "minecraft:block/cherry_planks",
+    "top": "minecraft:block/cherry_planks",
+    "bottom": "minecraft:block/cherry_planks",
+    "inside": "minecraft:block/cherry_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/cherry_planks",
+    "side": "minecraft:block/cherry_planks",
+    "top": "minecraft:block/cherry_planks",
+    "bottom": "minecraft:block/cherry_planks",
+    "inside": "minecraft:block/cherry_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "deep_aether:block/conberry_planks",
+    "side": "deep_aether:block/conberry_planks",
+    "top": "deep_aether:block/conberry_planks",
+    "bottom": "deep_aether:block/conberry_planks",
+    "inside": "deep_aether:block/conberry_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/conberry_planks",
+    "side": "deep_aether:block/conberry_planks",
+    "top": "deep_aether:block/conberry_planks",
+    "bottom": "deep_aether:block/conberry_planks",
+    "inside": "deep_aether:block/conberry_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/conberry_planks",
+    "side": "deep_aether:block/conberry_planks",
+    "top": "deep_aether:block/conberry_planks",
+    "bottom": "deep_aether:block/conberry_planks",
+    "inside": "deep_aether:block/conberry_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/crimson_planks",
+    "side": "minecraft:block/crimson_planks",
+    "top": "minecraft:block/crimson_planks",
+    "bottom": "minecraft:block/crimson_planks",
+    "inside": "minecraft:block/crimson_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/crimson_planks",
+    "side": "minecraft:block/crimson_planks",
+    "top": "minecraft:block/crimson_planks",
+    "bottom": "minecraft:block/crimson_planks",
+    "inside": "minecraft:block/crimson_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/crimson_planks",
+    "side": "minecraft:block/crimson_planks",
+    "top": "minecraft:block/crimson_planks",
+    "bottom": "minecraft:block/crimson_planks",
+    "inside": "minecraft:block/crimson_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "deep_aether:block/cruderoot_planks",
+    "side": "deep_aether:block/cruderoot_planks",
+    "top": "deep_aether:block/cruderoot_planks",
+    "bottom": "deep_aether:block/cruderoot_planks",
+    "inside": "deep_aether:block/cruderoot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/cruderoot_planks",
+    "side": "deep_aether:block/cruderoot_planks",
+    "top": "deep_aether:block/cruderoot_planks",
+    "bottom": "deep_aether:block/cruderoot_planks",
+    "inside": "deep_aether:block/cruderoot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/cruderoot_planks",
+    "side": "deep_aether:block/cruderoot_planks",
+    "top": "deep_aether:block/cruderoot_planks",
+    "bottom": "deep_aether:block/cruderoot_planks",
+    "inside": "deep_aether:block/cruderoot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/dark_oak_planks",
+    "side": "minecraft:block/dark_oak_planks",
+    "top": "minecraft:block/dark_oak_planks",
+    "bottom": "minecraft:block/dark_oak_planks",
+    "inside": "minecraft:block/dark_oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/dark_planks",
+    "side": "twilightforest:block/dark_planks",
+    "top": "twilightforest:block/dark_planks",
+    "bottom": "twilightforest:block/dark_planks",
+    "inside": "twilightforest:block/dark_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/dark_planks",
+    "side": "twilightforest:block/dark_planks",
+    "top": "twilightforest:block/dark_planks",
+    "bottom": "twilightforest:block/dark_planks",
+    "inside": "twilightforest:block/dark_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/dark_planks",
+    "side": "twilightforest:block/dark_planks",
+    "top": "twilightforest:block/dark_planks",
+    "bottom": "twilightforest:block/dark_planks",
+    "inside": "twilightforest:block/dark_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/dead_planks",
+    "side": "biomesoplenty:block/dead_planks",
+    "top": "biomesoplenty:block/dead_planks",
+    "bottom": "biomesoplenty:block/dead_planks",
+    "inside": "biomesoplenty:block/dead_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/dead_planks",
+    "side": "biomesoplenty:block/dead_planks",
+    "top": "biomesoplenty:block/dead_planks",
+    "bottom": "biomesoplenty:block/dead_planks",
+    "inside": "biomesoplenty:block/dead_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/dead_planks",
+    "side": "biomesoplenty:block/dead_planks",
+    "top": "biomesoplenty:block/dead_planks",
+    "bottom": "biomesoplenty:block/dead_planks",
+    "inside": "biomesoplenty:block/dead_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/empyreal_planks",
+    "side": "biomesoplenty:block/empyreal_planks",
+    "top": "biomesoplenty:block/empyreal_planks",
+    "bottom": "biomesoplenty:block/empyreal_planks",
+    "inside": "biomesoplenty:block/empyreal_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/empyreal_planks",
+    "side": "biomesoplenty:block/empyreal_planks",
+    "top": "biomesoplenty:block/empyreal_planks",
+    "bottom": "biomesoplenty:block/empyreal_planks",
+    "inside": "biomesoplenty:block/empyreal_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/empyreal_planks",
+    "side": "biomesoplenty:block/empyreal_planks",
+    "top": "biomesoplenty:block/empyreal_planks",
+    "bottom": "biomesoplenty:block/empyreal_planks",
+    "inside": "biomesoplenty:block/empyreal_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/fir_planks",
+    "side": "biomesoplenty:block/fir_planks",
+    "top": "biomesoplenty:block/fir_planks",
+    "bottom": "biomesoplenty:block/fir_planks",
+    "inside": "biomesoplenty:block/fir_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/fir_planks",
+    "side": "biomesoplenty:block/fir_planks",
+    "top": "biomesoplenty:block/fir_planks",
+    "bottom": "biomesoplenty:block/fir_planks",
+    "inside": "biomesoplenty:block/fir_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/fir_planks",
+    "side": "biomesoplenty:block/fir_planks",
+    "top": "biomesoplenty:block/fir_planks",
+    "bottom": "biomesoplenty:block/fir_planks",
+    "inside": "biomesoplenty:block/fir_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/hellbark_planks",
+    "side": "biomesoplenty:block/hellbark_planks",
+    "top": "biomesoplenty:block/hellbark_planks",
+    "bottom": "biomesoplenty:block/hellbark_planks",
+    "inside": "biomesoplenty:block/hellbark_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/hellbark_planks",
+    "side": "biomesoplenty:block/hellbark_planks",
+    "top": "biomesoplenty:block/hellbark_planks",
+    "bottom": "biomesoplenty:block/hellbark_planks",
+    "inside": "biomesoplenty:block/hellbark_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/hellbark_planks",
+    "side": "biomesoplenty:block/hellbark_planks",
+    "top": "biomesoplenty:block/hellbark_planks",
+    "bottom": "biomesoplenty:block/hellbark_planks",
+    "inside": "biomesoplenty:block/hellbark_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/jacaranda_planks",
+    "side": "biomesoplenty:block/jacaranda_planks",
+    "top": "biomesoplenty:block/jacaranda_planks",
+    "bottom": "biomesoplenty:block/jacaranda_planks",
+    "inside": "biomesoplenty:block/jacaranda_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/jacaranda_planks",
+    "side": "biomesoplenty:block/jacaranda_planks",
+    "top": "biomesoplenty:block/jacaranda_planks",
+    "bottom": "biomesoplenty:block/jacaranda_planks",
+    "inside": "biomesoplenty:block/jacaranda_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/jacaranda_planks",
+    "side": "biomesoplenty:block/jacaranda_planks",
+    "top": "biomesoplenty:block/jacaranda_planks",
+    "bottom": "biomesoplenty:block/jacaranda_planks",
+    "inside": "biomesoplenty:block/jacaranda_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/jungle_planks",
+    "side": "minecraft:block/jungle_planks",
+    "top": "minecraft:block/jungle_planks",
+    "bottom": "minecraft:block/jungle_planks",
+    "inside": "minecraft:block/jungle_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/magic_planks",
+    "side": "biomesoplenty:block/magic_planks",
+    "top": "biomesoplenty:block/magic_planks",
+    "bottom": "biomesoplenty:block/magic_planks",
+    "inside": "biomesoplenty:block/magic_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/magic_planks",
+    "side": "biomesoplenty:block/magic_planks",
+    "top": "biomesoplenty:block/magic_planks",
+    "bottom": "biomesoplenty:block/magic_planks",
+    "inside": "biomesoplenty:block/magic_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/magic_planks",
+    "side": "biomesoplenty:block/magic_planks",
+    "top": "biomesoplenty:block/magic_planks",
+    "bottom": "biomesoplenty:block/magic_planks",
+    "inside": "biomesoplenty:block/magic_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/mahogany_planks",
+    "side": "biomesoplenty:block/mahogany_planks",
+    "top": "biomesoplenty:block/mahogany_planks",
+    "bottom": "biomesoplenty:block/mahogany_planks",
+    "inside": "biomesoplenty:block/mahogany_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/mahogany_planks",
+    "side": "biomesoplenty:block/mahogany_planks",
+    "top": "biomesoplenty:block/mahogany_planks",
+    "bottom": "biomesoplenty:block/mahogany_planks",
+    "inside": "biomesoplenty:block/mahogany_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/mahogany_planks",
+    "side": "biomesoplenty:block/mahogany_planks",
+    "top": "biomesoplenty:block/mahogany_planks",
+    "bottom": "biomesoplenty:block/mahogany_planks",
+    "inside": "biomesoplenty:block/mahogany_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/mangrove_planks",
+    "side": "minecraft:block/mangrove_planks",
+    "top": "minecraft:block/mangrove_planks",
+    "bottom": "minecraft:block/mangrove_planks",
+    "inside": "minecraft:block/mangrove_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/maple_planks",
+    "side": "biomesoplenty:block/maple_planks",
+    "top": "biomesoplenty:block/maple_planks",
+    "bottom": "biomesoplenty:block/maple_planks",
+    "inside": "biomesoplenty:block/maple_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/maple_planks",
+    "side": "biomesoplenty:block/maple_planks",
+    "top": "biomesoplenty:block/maple_planks",
+    "bottom": "biomesoplenty:block/maple_planks",
+    "inside": "biomesoplenty:block/maple_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/maple_planks",
+    "side": "biomesoplenty:block/maple_planks",
+    "top": "biomesoplenty:block/maple_planks",
+    "bottom": "biomesoplenty:block/maple_planks",
+    "inside": "biomesoplenty:block/maple_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/mining_planks",
+    "side": "twilightforest:block/mining_planks",
+    "top": "twilightforest:block/mining_planks",
+    "bottom": "twilightforest:block/mining_planks",
+    "inside": "twilightforest:block/mining_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/mining_planks",
+    "side": "twilightforest:block/mining_planks",
+    "top": "twilightforest:block/mining_planks",
+    "bottom": "twilightforest:block/mining_planks",
+    "inside": "twilightforest:block/mining_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/mining_planks",
+    "side": "twilightforest:block/mining_planks",
+    "top": "twilightforest:block/mining_planks",
+    "bottom": "twilightforest:block/mining_planks",
+    "inside": "twilightforest:block/mining_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/palm_planks",
+    "side": "biomesoplenty:block/palm_planks",
+    "top": "biomesoplenty:block/palm_planks",
+    "bottom": "biomesoplenty:block/palm_planks",
+    "inside": "biomesoplenty:block/palm_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/palm_planks",
+    "side": "biomesoplenty:block/palm_planks",
+    "top": "biomesoplenty:block/palm_planks",
+    "bottom": "biomesoplenty:block/palm_planks",
+    "inside": "biomesoplenty:block/palm_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/palm_planks",
+    "side": "biomesoplenty:block/palm_planks",
+    "top": "biomesoplenty:block/palm_planks",
+    "bottom": "biomesoplenty:block/palm_planks",
+    "inside": "biomesoplenty:block/palm_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/pine_planks",
+    "side": "biomesoplenty:block/pine_planks",
+    "top": "biomesoplenty:block/pine_planks",
+    "bottom": "biomesoplenty:block/pine_planks",
+    "inside": "biomesoplenty:block/pine_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/pine_planks",
+    "side": "biomesoplenty:block/pine_planks",
+    "top": "biomesoplenty:block/pine_planks",
+    "bottom": "biomesoplenty:block/pine_planks",
+    "inside": "biomesoplenty:block/pine_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/pine_planks",
+    "side": "biomesoplenty:block/pine_planks",
+    "top": "biomesoplenty:block/pine_planks",
+    "bottom": "biomesoplenty:block/pine_planks",
+    "inside": "biomesoplenty:block/pine_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/redwood_planks",
+    "side": "biomesoplenty:block/redwood_planks",
+    "top": "biomesoplenty:block/redwood_planks",
+    "bottom": "biomesoplenty:block/redwood_planks",
+    "inside": "biomesoplenty:block/redwood_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/redwood_planks",
+    "side": "biomesoplenty:block/redwood_planks",
+    "top": "biomesoplenty:block/redwood_planks",
+    "bottom": "biomesoplenty:block/redwood_planks",
+    "inside": "biomesoplenty:block/redwood_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/redwood_planks",
+    "side": "biomesoplenty:block/redwood_planks",
+    "top": "biomesoplenty:block/redwood_planks",
+    "bottom": "biomesoplenty:block/redwood_planks",
+    "inside": "biomesoplenty:block/redwood_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "deep_aether:block/roseroot_planks",
+    "side": "deep_aether:block/roseroot_planks",
+    "top": "deep_aether:block/roseroot_planks",
+    "bottom": "deep_aether:block/roseroot_planks",
+    "inside": "deep_aether:block/roseroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/roseroot_planks",
+    "side": "deep_aether:block/roseroot_planks",
+    "top": "deep_aether:block/roseroot_planks",
+    "bottom": "deep_aether:block/roseroot_planks",
+    "inside": "deep_aether:block/roseroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/roseroot_planks",
+    "side": "deep_aether:block/roseroot_planks",
+    "top": "deep_aether:block/roseroot_planks",
+    "bottom": "deep_aether:block/roseroot_planks",
+    "inside": "deep_aether:block/roseroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "aether:block/skyroot_planks",
+    "side": "aether:block/skyroot_planks",
+    "top": "aether:block/skyroot_planks",
+    "bottom": "aether:block/skyroot_planks",
+    "inside": "aether:block/skyroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "aether:block/skyroot_planks",
+    "side": "aether:block/skyroot_planks",
+    "top": "aether:block/skyroot_planks",
+    "bottom": "aether:block/skyroot_planks",
+    "inside": "aether:block/skyroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "aether:block/skyroot_planks",
+    "side": "aether:block/skyroot_planks",
+    "top": "aether:block/skyroot_planks",
+    "bottom": "aether:block/skyroot_planks",
+    "inside": "aether:block/skyroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/sorting_planks",
+    "side": "twilightforest:block/sorting_planks",
+    "top": "twilightforest:block/sorting_planks",
+    "bottom": "twilightforest:block/sorting_planks",
+    "inside": "twilightforest:block/sorting_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/sorting_planks",
+    "side": "twilightforest:block/sorting_planks",
+    "top": "twilightforest:block/sorting_planks",
+    "bottom": "twilightforest:block/sorting_planks",
+    "inside": "twilightforest:block/sorting_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/sorting_planks",
+    "side": "twilightforest:block/sorting_planks",
+    "top": "twilightforest:block/sorting_planks",
+    "bottom": "twilightforest:block/sorting_planks",
+    "inside": "twilightforest:block/sorting_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/spruce_planks",
+    "side": "minecraft:block/spruce_planks",
+    "top": "minecraft:block/spruce_planks",
+    "bottom": "minecraft:block/spruce_planks",
+    "inside": "minecraft:block/spruce_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "deep_aether:block/sunroot_planks",
+    "side": "deep_aether:block/sunroot_planks",
+    "top": "deep_aether:block/sunroot_planks",
+    "bottom": "deep_aether:block/sunroot_planks",
+    "inside": "deep_aether:block/sunroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/sunroot_planks",
+    "side": "deep_aether:block/sunroot_planks",
+    "top": "deep_aether:block/sunroot_planks",
+    "bottom": "deep_aether:block/sunroot_planks",
+    "inside": "deep_aether:block/sunroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/sunroot_planks",
+    "side": "deep_aether:block/sunroot_planks",
+    "top": "deep_aether:block/sunroot_planks",
+    "bottom": "deep_aether:block/sunroot_planks",
+    "inside": "deep_aether:block/sunroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/time_planks",
+    "side": "twilightforest:block/time_planks",
+    "top": "twilightforest:block/time_planks",
+    "bottom": "twilightforest:block/time_planks",
+    "inside": "twilightforest:block/time_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/time_planks",
+    "side": "twilightforest:block/time_planks",
+    "top": "twilightforest:block/time_planks",
+    "bottom": "twilightforest:block/time_planks",
+    "inside": "twilightforest:block/time_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/time_planks",
+    "side": "twilightforest:block/time_planks",
+    "top": "twilightforest:block/time_planks",
+    "bottom": "twilightforest:block/time_planks",
+    "inside": "twilightforest:block/time_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/towerwood",
+    "side": "twilightforest:block/towerwood",
+    "top": "twilightforest:block/towerwood",
+    "bottom": "twilightforest:block/towerwood",
+    "inside": "twilightforest:block/towerwood",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/towerwood",
+    "side": "twilightforest:block/towerwood",
+    "top": "twilightforest:block/towerwood",
+    "bottom": "twilightforest:block/towerwood",
+    "inside": "twilightforest:block/towerwood",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/towerwood",
+    "side": "twilightforest:block/towerwood",
+    "top": "twilightforest:block/towerwood",
+    "bottom": "twilightforest:block/towerwood",
+    "inside": "twilightforest:block/towerwood",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/transformation_planks",
+    "side": "twilightforest:block/transformation_planks",
+    "top": "twilightforest:block/transformation_planks",
+    "bottom": "twilightforest:block/transformation_planks",
+    "inside": "twilightforest:block/transformation_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/transformation_planks",
+    "side": "twilightforest:block/transformation_planks",
+    "top": "twilightforest:block/transformation_planks",
+    "bottom": "twilightforest:block/transformation_planks",
+    "inside": "twilightforest:block/transformation_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/transformation_planks",
+    "side": "twilightforest:block/transformation_planks",
+    "top": "twilightforest:block/transformation_planks",
+    "bottom": "twilightforest:block/transformation_planks",
+    "inside": "twilightforest:block/transformation_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/mangrove_planks",
+    "side": "twilightforest:block/mangrove_planks",
+    "top": "twilightforest:block/mangrove_planks",
+    "bottom": "twilightforest:block/mangrove_planks",
+    "inside": "twilightforest:block/mangrove_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/mangrove_planks",
+    "side": "twilightforest:block/mangrove_planks",
+    "top": "twilightforest:block/mangrove_planks",
+    "bottom": "twilightforest:block/mangrove_planks",
+    "inside": "twilightforest:block/mangrove_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/mangrove_planks",
+    "side": "twilightforest:block/mangrove_planks",
+    "top": "twilightforest:block/mangrove_planks",
+    "bottom": "twilightforest:block/mangrove_planks",
+    "inside": "twilightforest:block/mangrove_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "twilightforest:block/twilight_oak_planks",
+    "side": "twilightforest:block/twilight_oak_planks",
+    "top": "twilightforest:block/twilight_oak_planks",
+    "bottom": "twilightforest:block/twilight_oak_planks",
+    "inside": "twilightforest:block/twilight_oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "twilightforest:block/twilight_oak_planks",
+    "side": "twilightforest:block/twilight_oak_planks",
+    "top": "twilightforest:block/twilight_oak_planks",
+    "bottom": "twilightforest:block/twilight_oak_planks",
+    "inside": "twilightforest:block/twilight_oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "twilightforest:block/twilight_oak_planks",
+    "side": "twilightforest:block/twilight_oak_planks",
+    "top": "twilightforest:block/twilight_oak_planks",
+    "bottom": "twilightforest:block/twilight_oak_planks",
+    "inside": "twilightforest:block/twilight_oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/umbran_planks",
+    "side": "biomesoplenty:block/umbran_planks",
+    "top": "biomesoplenty:block/umbran_planks",
+    "bottom": "biomesoplenty:block/umbran_planks",
+    "inside": "biomesoplenty:block/umbran_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/umbran_planks",
+    "side": "biomesoplenty:block/umbran_planks",
+    "top": "biomesoplenty:block/umbran_planks",
+    "bottom": "biomesoplenty:block/umbran_planks",
+    "inside": "biomesoplenty:block/umbran_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/umbran_planks",
+    "side": "biomesoplenty:block/umbran_planks",
+    "top": "biomesoplenty:block/umbran_planks",
+    "bottom": "biomesoplenty:block/umbran_planks",
+    "inside": "biomesoplenty:block/umbran_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/warped_planks",
+    "side": "minecraft:block/warped_planks",
+    "top": "minecraft:block/warped_planks",
+    "bottom": "minecraft:block/warped_planks",
+    "inside": "minecraft:block/warped_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/warped_planks",
+    "side": "minecraft:block/warped_planks",
+    "top": "minecraft:block/warped_planks",
+    "bottom": "minecraft:block/warped_planks",
+    "inside": "minecraft:block/warped_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/warped_planks",
+    "side": "minecraft:block/warped_planks",
+    "top": "minecraft:block/warped_planks",
+    "bottom": "minecraft:block/warped_planks",
+    "inside": "minecraft:block/warped_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "biomesoplenty:block/willow_planks",
+    "side": "biomesoplenty:block/willow_planks",
+    "top": "biomesoplenty:block/willow_planks",
+    "bottom": "biomesoplenty:block/willow_planks",
+    "inside": "biomesoplenty:block/willow_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "biomesoplenty:block/willow_planks",
+    "side": "biomesoplenty:block/willow_planks",
+    "top": "biomesoplenty:block/willow_planks",
+    "bottom": "biomesoplenty:block/willow_planks",
+    "inside": "biomesoplenty:block/willow_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "biomesoplenty:block/willow_planks",
+    "side": "biomesoplenty:block/willow_planks",
+    "top": "biomesoplenty:block/willow_planks",
+    "bottom": "biomesoplenty:block/willow_planks",
+    "inside": "biomesoplenty:block/willow_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "minecraft:block/oak_planks",
+    "side": "minecraft:block/oak_planks",
+    "top": "minecraft:block/oak_planks",
+    "bottom": "minecraft:block/oak_planks",
+    "inside": "minecraft:block/oak_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_full.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_full.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_full",
+  "textures": {
+    "particle": "deep_aether:block/yagroot_planks",
+    "side": "deep_aether:block/yagroot_planks",
+    "top": "deep_aether:block/yagroot_planks",
+    "bottom": "deep_aether:block/yagroot_planks",
+    "inside": "deep_aether:block/yagroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level1.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level1.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level1",
+  "textures": {
+    "particle": "deep_aether:block/yagroot_planks",
+    "side": "deep_aether:block/yagroot_planks",
+    "top": "deep_aether:block/yagroot_planks",
+    "bottom": "deep_aether:block/yagroot_planks",
+    "inside": "deep_aether:block/yagroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level2.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_water_cauldron_level2.json
@@ -1,0 +1,11 @@
+{
+  "parent": "minecraft:block/template_cauldron_level2",
+  "textures": {
+    "particle": "deep_aether:block/yagroot_planks",
+    "side": "deep_aether:block/yagroot_planks",
+    "top": "deep_aether:block/yagroot_planks",
+    "bottom": "deep_aether:block/yagroot_planks",
+    "inside": "deep_aether:block/yagroot_planks",
+    "content": "minecraft:block/water_still"
+  }
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/acacia_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/acacia_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:acacia_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/acacia_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/bamboo_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/bamboo_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:bamboo_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/bamboo_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/birch_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/birch_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:birch_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/birch_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/canopy_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/canopy_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:canopy_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/canopy_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/cherry_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/cherry_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:cherry_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/cherry_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/conberry_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/conberry_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:conberry_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/conberry_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/crimson_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/crimson_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:crimson_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/crimson_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/cruderoot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/cruderoot_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:cruderoot_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/cruderoot_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_oak_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_oak_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:dark_oak_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/dark_oak_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/dark_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:dark_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/dark_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/dead_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/dead_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:dead_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/dead_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/empyreal_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/empyreal_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:empyreal_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/empyreal_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/fir_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/fir_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:fir_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/fir_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/hellbark_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/hellbark_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:hellbark_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/hellbark_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/jacaranda_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/jacaranda_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:jacaranda_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/jacaranda_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/jungle_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/jungle_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:jungle_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/jungle_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/magic_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/magic_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:magic_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/magic_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/mahogany_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/mahogany_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:mahogany_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/mahogany_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/mangrove_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:mangrove_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/mangrove_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/maple_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/maple_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:maple_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/maple_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/mining_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/mining_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:mining_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/mining_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/oak_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/oak_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:oak_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/oak_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/palm_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/palm_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:palm_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/palm_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/pine_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/pine_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:pine_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/pine_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/redwood_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/redwood_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:redwood_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/redwood_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/roseroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/roseroot_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:roseroot_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/roseroot_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/skyroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/skyroot_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:skyroot_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/skyroot_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/sorting_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/sorting_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:sorting_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/sorting_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/spruce_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/spruce_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:spruce_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/spruce_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/sunroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/sunroot_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:sunroot_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/sunroot_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/time_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/time_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:time_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/time_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/towerwood_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/towerwood_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:towerwood_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/towerwood_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/transformation_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/transformation_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:transformation_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/transformation_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_mangrove_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_mangrove_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:twilight_mangrove_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/twilight_mangrove_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_oak_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/twilight_oak_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:twilight_oak_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/twilight_oak_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/umbran_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/umbran_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:umbran_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/umbran_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/warped_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/warped_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:warped_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/warped_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/willow_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/willow_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:willow_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/willow_wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/wooden_water_cauldron"
+}

--- a/src/main/resources/data/woodenutilities/loot_tables/blocks/yagroot_wooden_water_cauldron.json
+++ b/src/main/resources/data/woodenutilities/loot_tables/blocks/yagroot_wooden_water_cauldron.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "woodenutilities:yagroot_wooden_cauldron"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ],
+  "random_sequence": "woodenutilities:blocks/yagroot_wooden_water_cauldron"
+}


### PR DESCRIPTION
### Motivation
- Fix the earlier regression that blocked water-bucket filling of wooden cauldrons by preventing bucket-driven conversion to the vanilla cauldron while still allowing filling a wooden cauldron with a water bucket.  
- Ensure every wooden cauldron variant preserves its wooden identity when filled instead of turning into the vanilla `Cauldron` block.

### Description
- Added `WoodenWaterCauldronBlock` (extends `LayeredCauldronBlock`) with custom bucket pickup logic so full wooden water cauldrons return a `WATER_BUCKET` and revert to the matching empty wooden cauldron.  
- Updated `WoodenCauldronBlock#use` to short-circuit `Items.WATER_BUCKET` interactions by filling the matching wooden water cauldron (via a `Supplier<Block>`), playing sounds and emitting the appropriate game events, while still blocking other non-empty `BucketItem` conversions.  
- Updated `ModBlocks` to register paired `*_wooden_water_cauldron` entries and wire them to their empty wooden cauldrons so filling/emptying maps to the correct wooden variants.  
- Added blockstates, models, and loot table resources for all wooden water cauldron variants so the new water blocks have correct visuals and drops (many new resource files added across assets/data).

### Testing
- Attempted to run `./gradlew --no-daemon compileJava`, but the Gradle wrapper was not present so compilation could not be executed and the build step failed.  
- Performed static inspections and file checks (`sed`, `nl`, repo status) to verify the new classes, registrations, and resource files were created and wired; these file-level checks succeeded.  
- No automated game/runtime tests were executed due to the missing gradle wrapper and the inability to run a full build in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876a1049f883338beaa7d80b078e8a)