### PR TITLE
Use barrel textures for wooden barrel models

### DIFF
--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/acacia_planks",
-    "side": "minecraft:block/acacia_planks",
-    "top": "minecraft:block/acacia_planks",
-    "bottom": "minecraft:block/acacia_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/acacia_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/acacia_planks",
-    "side": "minecraft:block/acacia_planks",
-    "top": "minecraft:block/acacia_planks",
-    "bottom": "minecraft:block/acacia_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/bamboo_planks",
-    "side": "minecraft:block/bamboo_planks",
-    "top": "minecraft:block/bamboo_planks",
-    "bottom": "minecraft:block/bamboo_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/bamboo_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/bamboo_planks",
-    "side": "minecraft:block/bamboo_planks",
-    "top": "minecraft:block/bamboo_planks",
-    "bottom": "minecraft:block/bamboo_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/birch_planks",
-    "side": "minecraft:block/birch_planks",
-    "top": "minecraft:block/birch_planks",
-    "bottom": "minecraft:block/birch_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/birch_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/birch_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/birch_planks",
-    "side": "minecraft:block/birch_planks",
-    "top": "minecraft:block/birch_planks",
-    "bottom": "minecraft:block/birch_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/wood/planks/canopy/canopy_planks",
-    "side": "twilightforest:block/wood/planks/canopy/canopy_planks",
-    "top": "twilightforest:block/wood/planks/canopy/canopy_planks",
-    "bottom": "twilightforest:block/wood/planks/canopy/canopy_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/canopy_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/wood/planks/canopy/canopy_planks",
-    "side": "twilightforest:block/wood/planks/canopy/canopy_planks",
-    "top": "twilightforest:block/wood/planks/canopy/canopy_planks",
-    "bottom": "twilightforest:block/wood/planks/canopy/canopy_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/cherry_planks",
-    "side": "minecraft:block/cherry_planks",
-    "top": "minecraft:block/cherry_planks",
-    "bottom": "minecraft:block/cherry_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cherry_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/cherry_planks",
-    "side": "minecraft:block/cherry_planks",
-    "top": "minecraft:block/cherry_planks",
-    "bottom": "minecraft:block/cherry_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "deep_aether:block/conberry_planks",
-    "side": "deep_aether:block/conberry_planks",
-    "top": "deep_aether:block/conberry_planks",
-    "bottom": "deep_aether:block/conberry_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/conberry_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "deep_aether:block/conberry_planks",
-    "side": "deep_aether:block/conberry_planks",
-    "top": "deep_aether:block/conberry_planks",
-    "bottom": "deep_aether:block/conberry_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/crimson_planks",
-    "side": "minecraft:block/crimson_planks",
-    "top": "minecraft:block/crimson_planks",
-    "bottom": "minecraft:block/crimson_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/crimson_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/crimson_planks",
-    "side": "minecraft:block/crimson_planks",
-    "top": "minecraft:block/crimson_planks",
-    "bottom": "minecraft:block/crimson_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "deep_aether:block/cruderoot_planks",
-    "side": "deep_aether:block/cruderoot_planks",
-    "top": "deep_aether:block/cruderoot_planks",
-    "bottom": "deep_aether:block/cruderoot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/cruderoot_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "deep_aether:block/cruderoot_planks",
-    "side": "deep_aether:block/cruderoot_planks",
-    "top": "deep_aether:block/cruderoot_planks",
-    "bottom": "deep_aether:block/cruderoot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/dark_oak_planks",
-    "side": "minecraft:block/dark_oak_planks",
-    "top": "minecraft:block/dark_oak_planks",
-    "bottom": "minecraft:block/dark_oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_oak_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/dark_oak_planks",
-    "side": "minecraft:block/dark_oak_planks",
-    "top": "minecraft:block/dark_oak_planks",
-    "bottom": "minecraft:block/dark_oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/darkwood_planks",
-    "side": "twilightforest:block/darkwood_planks",
-    "top": "twilightforest:block/darkwood_planks",
-    "bottom": "twilightforest:block/darkwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/dark_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dark_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/darkwood_planks",
-    "side": "twilightforest:block/darkwood_planks",
-    "top": "twilightforest:block/darkwood_planks",
-    "bottom": "twilightforest:block/darkwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/dead_planks",
-    "side": "biomesoplenty:block/dead_planks",
-    "top": "biomesoplenty:block/dead_planks",
-    "bottom": "biomesoplenty:block/dead_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/dead_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/dead_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/dead_planks",
-    "side": "biomesoplenty:block/dead_planks",
-    "top": "biomesoplenty:block/dead_planks",
-    "bottom": "biomesoplenty:block/dead_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/empyreal_planks",
-    "side": "biomesoplenty:block/empyreal_planks",
-    "top": "biomesoplenty:block/empyreal_planks",
-    "bottom": "biomesoplenty:block/empyreal_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/empyreal_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/empyreal_planks",
-    "side": "biomesoplenty:block/empyreal_planks",
-    "top": "biomesoplenty:block/empyreal_planks",
-    "bottom": "biomesoplenty:block/empyreal_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/fir_planks",
-    "side": "biomesoplenty:block/fir_planks",
-    "top": "biomesoplenty:block/fir_planks",
-    "bottom": "biomesoplenty:block/fir_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/fir_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/fir_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/fir_planks",
-    "side": "biomesoplenty:block/fir_planks",
-    "top": "biomesoplenty:block/fir_planks",
-    "bottom": "biomesoplenty:block/fir_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/hellbark_planks",
-    "side": "biomesoplenty:block/hellbark_planks",
-    "top": "biomesoplenty:block/hellbark_planks",
-    "bottom": "biomesoplenty:block/hellbark_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/hellbark_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/hellbark_planks",
-    "side": "biomesoplenty:block/hellbark_planks",
-    "top": "biomesoplenty:block/hellbark_planks",
-    "bottom": "biomesoplenty:block/hellbark_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/jacaranda_planks",
-    "side": "biomesoplenty:block/jacaranda_planks",
-    "top": "biomesoplenty:block/jacaranda_planks",
-    "bottom": "biomesoplenty:block/jacaranda_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jacaranda_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/jacaranda_planks",
-    "side": "biomesoplenty:block/jacaranda_planks",
-    "top": "biomesoplenty:block/jacaranda_planks",
-    "bottom": "biomesoplenty:block/jacaranda_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/jungle_planks",
-    "side": "minecraft:block/jungle_planks",
-    "top": "minecraft:block/jungle_planks",
-    "bottom": "minecraft:block/jungle_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/jungle_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/jungle_planks",
-    "side": "minecraft:block/jungle_planks",
-    "top": "minecraft:block/jungle_planks",
-    "bottom": "minecraft:block/jungle_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/magic_planks",
-    "side": "biomesoplenty:block/magic_planks",
-    "top": "biomesoplenty:block/magic_planks",
-    "bottom": "biomesoplenty:block/magic_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/magic_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/magic_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/magic_planks",
-    "side": "biomesoplenty:block/magic_planks",
-    "top": "biomesoplenty:block/magic_planks",
-    "bottom": "biomesoplenty:block/magic_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/mahogany_planks",
-    "side": "biomesoplenty:block/mahogany_planks",
-    "top": "biomesoplenty:block/mahogany_planks",
-    "bottom": "biomesoplenty:block/mahogany_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mahogany_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/mahogany_planks",
-    "side": "biomesoplenty:block/mahogany_planks",
-    "top": "biomesoplenty:block/mahogany_planks",
-    "bottom": "biomesoplenty:block/mahogany_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/mangrove_planks",
-    "side": "minecraft:block/mangrove_planks",
-    "top": "minecraft:block/mangrove_planks",
-    "bottom": "minecraft:block/mangrove_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mangrove_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/mangrove_planks",
-    "side": "minecraft:block/mangrove_planks",
-    "top": "minecraft:block/mangrove_planks",
-    "bottom": "minecraft:block/mangrove_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/maple_planks",
-    "side": "biomesoplenty:block/maple_planks",
-    "top": "biomesoplenty:block/maple_planks",
-    "bottom": "biomesoplenty:block/maple_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/maple_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/maple_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/maple_planks",
-    "side": "biomesoplenty:block/maple_planks",
-    "top": "biomesoplenty:block/maple_planks",
-    "bottom": "biomesoplenty:block/maple_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/minewood_planks",
-    "side": "twilightforest:block/minewood_planks",
-    "top": "twilightforest:block/minewood_planks",
-    "bottom": "twilightforest:block/minewood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/mining_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/mining_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/minewood_planks",
-    "side": "twilightforest:block/minewood_planks",
-    "top": "twilightforest:block/minewood_planks",
-    "bottom": "twilightforest:block/minewood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/oak_planks",
-    "side": "minecraft:block/oak_planks",
-    "top": "minecraft:block/oak_planks",
-    "bottom": "minecraft:block/oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/oak_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/oak_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/oak_planks",
-    "side": "minecraft:block/oak_planks",
-    "top": "minecraft:block/oak_planks",
-    "bottom": "minecraft:block/oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/palm_planks",
-    "side": "biomesoplenty:block/palm_planks",
-    "top": "biomesoplenty:block/palm_planks",
-    "bottom": "biomesoplenty:block/palm_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/palm_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/palm_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/palm_planks",
-    "side": "biomesoplenty:block/palm_planks",
-    "top": "biomesoplenty:block/palm_planks",
-    "bottom": "biomesoplenty:block/palm_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/pine_planks",
-    "side": "biomesoplenty:block/pine_planks",
-    "top": "biomesoplenty:block/pine_planks",
-    "bottom": "biomesoplenty:block/pine_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/pine_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/pine_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/pine_planks",
-    "side": "biomesoplenty:block/pine_planks",
-    "top": "biomesoplenty:block/pine_planks",
-    "bottom": "biomesoplenty:block/pine_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/redwood_planks",
-    "side": "biomesoplenty:block/redwood_planks",
-    "top": "biomesoplenty:block/redwood_planks",
-    "bottom": "biomesoplenty:block/redwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/redwood_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/redwood_planks",
-    "side": "biomesoplenty:block/redwood_planks",
-    "top": "biomesoplenty:block/redwood_planks",
-    "bottom": "biomesoplenty:block/redwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "deep_aether:block/roseroot_planks",
-    "side": "deep_aether:block/roseroot_planks",
-    "top": "deep_aether:block/roseroot_planks",
-    "bottom": "deep_aether:block/roseroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/roseroot_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "deep_aether:block/roseroot_planks",
-    "side": "deep_aether:block/roseroot_planks",
-    "top": "deep_aether:block/roseroot_planks",
-    "bottom": "deep_aether:block/roseroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "aether:block/wood/planks/skyroot/skyroot_planks",
-    "side": "aether:block/wood/planks/skyroot/skyroot_planks",
-    "top": "aether:block/wood/planks/skyroot/skyroot_planks",
-    "bottom": "aether:block/wood/planks/skyroot/skyroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/skyroot_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "aether:block/wood/planks/skyroot/skyroot_planks",
-    "side": "aether:block/wood/planks/skyroot/skyroot_planks",
-    "top": "aether:block/wood/planks/skyroot/skyroot_planks",
-    "bottom": "aether:block/wood/planks/skyroot/skyroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/sortwood_planks",
-    "side": "twilightforest:block/sortwood_planks",
-    "top": "twilightforest:block/sortwood_planks",
-    "bottom": "twilightforest:block/sortwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sorting_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/sortwood_planks",
-    "side": "twilightforest:block/sortwood_planks",
-    "top": "twilightforest:block/sortwood_planks",
-    "bottom": "twilightforest:block/sortwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/spruce_planks",
-    "side": "minecraft:block/spruce_planks",
-    "top": "minecraft:block/spruce_planks",
-    "bottom": "minecraft:block/spruce_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/spruce_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/spruce_planks",
-    "side": "minecraft:block/spruce_planks",
-    "top": "minecraft:block/spruce_planks",
-    "bottom": "minecraft:block/spruce_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "deep_aether:block/sunroot_planks",
-    "side": "deep_aether:block/sunroot_planks",
-    "top": "deep_aether:block/sunroot_planks",
-    "bottom": "deep_aether:block/sunroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/sunroot_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "deep_aether:block/sunroot_planks",
-    "side": "deep_aether:block/sunroot_planks",
-    "top": "deep_aether:block/sunroot_planks",
-    "bottom": "deep_aether:block/sunroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/timewood_planks",
-    "side": "twilightforest:block/timewood_planks",
-    "top": "twilightforest:block/timewood_planks",
-    "bottom": "twilightforest:block/timewood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/time_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/time_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/timewood_planks",
-    "side": "twilightforest:block/timewood_planks",
-    "top": "twilightforest:block/timewood_planks",
-    "bottom": "twilightforest:block/timewood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/towerwood",
-    "side": "twilightforest:block/towerwood",
-    "top": "twilightforest:block/towerwood",
-    "bottom": "twilightforest:block/towerwood"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/towerwood_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/towerwood",
-    "side": "twilightforest:block/towerwood",
-    "top": "twilightforest:block/towerwood",
-    "bottom": "twilightforest:block/towerwood"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/transwood_planks",
-    "side": "twilightforest:block/transwood_planks",
-    "top": "twilightforest:block/transwood_planks",
-    "bottom": "twilightforest:block/transwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/transformation_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/transwood_planks",
-    "side": "twilightforest:block/transwood_planks",
-    "top": "twilightforest:block/transwood_planks",
-    "bottom": "twilightforest:block/transwood_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/wood/planks/mangrove/mangrove_planks",
-    "side": "twilightforest:block/wood/planks/mangrove/mangrove_planks",
-    "top": "twilightforest:block/wood/planks/mangrove/mangrove_planks",
-    "bottom": "twilightforest:block/wood/planks/mangrove/mangrove_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_mangrove_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/wood/planks/mangrove/mangrove_planks",
-    "side": "twilightforest:block/wood/planks/mangrove/mangrove_planks",
-    "top": "twilightforest:block/wood/planks/mangrove/mangrove_planks",
-    "bottom": "twilightforest:block/wood/planks/mangrove/mangrove_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks",
-    "side": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks",
-    "top": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks",
-    "bottom": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/twilight_oak_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks",
-    "side": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks",
-    "top": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks",
-    "bottom": "twilightforest:block/wood/planks/twilight_oak/twilight_oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/umbran_planks",
-    "side": "biomesoplenty:block/umbran_planks",
-    "top": "biomesoplenty:block/umbran_planks",
-    "bottom": "biomesoplenty:block/umbran_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/umbran_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/umbran_planks",
-    "side": "biomesoplenty:block/umbran_planks",
-    "top": "biomesoplenty:block/umbran_planks",
-    "bottom": "biomesoplenty:block/umbran_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/warped_planks",
-    "side": "minecraft:block/warped_planks",
-    "top": "minecraft:block/warped_planks",
-    "bottom": "minecraft:block/warped_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/warped_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/warped_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/warped_planks",
-    "side": "minecraft:block/warped_planks",
-    "top": "minecraft:block/warped_planks",
-    "bottom": "minecraft:block/warped_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "biomesoplenty:block/willow_planks",
-    "side": "biomesoplenty:block/willow_planks",
-    "top": "biomesoplenty:block/willow_planks",
-    "bottom": "biomesoplenty:block/willow_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/willow_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/willow_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "biomesoplenty:block/willow_planks",
-    "side": "biomesoplenty:block/willow_planks",
-    "top": "biomesoplenty:block/willow_planks",
-    "bottom": "biomesoplenty:block/willow_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "minecraft:block/oak_planks",
-    "side": "minecraft:block/oak_planks",
-    "top": "minecraft:block/oak_planks",
-    "bottom": "minecraft:block/oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "minecraft:block/oak_planks",
-    "side": "minecraft:block/oak_planks",
-    "top": "minecraft:block/oak_planks",
-    "bottom": "minecraft:block/oak_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_barrel.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_barrel.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel",
   "textures": {
-    "particle": "deep_aether:block/yagroot_planks",
-    "side": "deep_aether:block/yagroot_planks",
-    "top": "deep_aether:block/yagroot_planks",
-    "bottom": "deep_aether:block/yagroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }

--- a/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_barrel_open.json
+++ b/src/main/resources/assets/woodenutilities/models/block/yagroot_wooden_barrel_open.json
@@ -1,9 +1,9 @@
 {
   "parent": "minecraft:block/barrel_open",
   "textures": {
-    "particle": "deep_aether:block/yagroot_planks",
-    "side": "deep_aether:block/yagroot_planks",
-    "top": "deep_aether:block/yagroot_planks",
-    "bottom": "deep_aether:block/yagroot_planks"
+    "particle": "minecraft:block/barrel_side",
+    "side": "minecraft:block/barrel_side",
+    "top": "minecraft:block/barrel_top_open",
+    "bottom": "minecraft:block/barrel_bottom"
   }
 }


### PR DESCRIPTION
### Motivation
- Wooden barrel blocks were rendering using plank textures and appeared as planks instead of barrels.  
- Make closed and open barrel variants use the official barrel textures so visuals are consistent across wood types.

### Description
- Replaced per-wood plank texture references with barrel textures in `src/main/resources/assets/woodenutilities/models/block/*wooden_barrel*.json`.  
- Closed models now use `minecraft:block/barrel_side`, `minecraft:block/barrel_top`, and `minecraft:block/barrel_bottom`.  
- Open models now use `minecraft:block/barrel_side`, `minecraft:block/barrel_top_open`, and `minecraft:block/barrel_bottom`.  
- Changes applied across ~80 barrel model files including `wooden_barrel.json` and `*_open.json` variants and committed.

### Testing
- Ran the update script (a small Python script) that wrote the new texture mappings and reported `changed 80`.  
- Verified the modifications with `git status` and created a commit showing `80 files changed`.  
- No runtime or asset pipeline tests were executed because this is an asset-only model change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881ce9f4c083339e104f57305bc355)