### PR TITLE
Add wooden rods to forge:rods/wooden tag

### DIFF
--- a/src/main/resources/data/forge/tags/items/rods/wooden.json
+++ b/src/main/resources/data/forge/tags/items/rods/wooden.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "woodenutilities:oak_rod",
+    "woodenutilities:acacia_rod",
+    "woodenutilities:birch_rod",
+    "woodenutilities:dark_oak_rod",
+    "woodenutilities:jungle_rod",
+    "woodenutilities:spruce_rod"
+  ]
+}


### PR DESCRIPTION
Registers oak, acacia, birch, dark_oak, jungle, and spruce rods under the forge:rods/wooden item tag for cross-mod compatibility.

https://claude.ai/code/session_01UrkHpn46LpF2XJNfNArNdz