### PR TITLE
Pin net.neoforged.gradle.userdev to 7.0.184 for Gradle 8.11.1 compati…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'maven-publish'
     // Declared with apply=false so both land in the classpath; we apply one below.
     id 'net.minecraftforge.gradle' version '[6.0,6.2)' apply false
-    id 'net.neoforged.gradle.userdev' version '7.0.+' apply false
+    id 'net.neoforged.gradle.userdev' version '7.0.184' apply false
 }
 
 // ── Stonecutter: determine current build target ───────────────────────────────


### PR DESCRIPTION
…bility

7.0.185+ bumped the Gradle plugin API version to 8.13, breaking resolution under the pinned Gradle 8.11.1 wrapper. 7.0.184 was built against Gradle 8.10 and is the last release compatible with Gradle 8.11.1.

https://claude.ai/code/session_017pESUbCtST4oAm3wjvcwFA