### PR TITLE
Add support for Minecraft 26.x (NeoForge) with Java 25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ stonecutter.const 'neoforge', isNeoForge
 
 // MC version parsing for version-specific constants
 def mcVer = minecraft_version.tokenize('.')
+int mcMajor = mcVer[0].toInteger()
 int mcMinor = mcVer[1].toInteger()
 int mcPatch = mcVer.size() > 2 ? mcVer[2].toInteger() : 0
 
@@ -45,8 +46,8 @@ stonecutter.const 'recipe_holder', (isNeoForge || (isForge && !(mcMinor == 20 &&
 stonecutter.const 'modern_nbt', (isNeoForge || (isForge && (mcMinor > 20 || mcPatch >= 6)))
 
 // has_item_props: ItemProperties and ClampedItemPropertyFunction exist
-//                Removed in NeoForge 1.21.4+
-stonecutter.const 'has_item_props', !(isNeoForge && mcMinor == 21 && mcPatch >= 4)
+//                Removed in NeoForge 1.21.4+ and all 26.x+ versions
+stonecutter.const 'has_item_props', !(isNeoForge && (mcMajor >= 26 || (mcMinor == 21 && mcPatch >= 4)))
 
 // block_codec: BaseEntityBlock requires codec() override
 //              True for all except forge_1201
@@ -63,11 +64,12 @@ base {
     archivesName = mod_id
 }
 
-// Forge 1.20.6+ requires Java 21; older Forge uses Java 17
+// Minecraft 26.x (NeoForge) requires Java 25; Forge 1.20.6+ and all NeoForge <26 require Java 21; older Forge uses Java 17
 def mcParts = minecraft_version.split('\\.')
+boolean needsJava25 = isNeoForge && mcMajor >= 26
 boolean forgeNeedsJava21 = isForge && (mcParts[1].toInteger() > 20 ||
         (mcParts[1].toInteger() == 20 && mcParts.length > 2 && mcParts[2].toInteger() >= 6))
-java.toolchain.languageVersion = JavaLanguageVersion.of((isNeoForge || forgeNeedsJava21) ? 21 : 17)
+java.toolchain.languageVersion = JavaLanguageVersion.of(needsJava25 ? 25 : (isNeoForge || forgeNeedsJava21) ? 21 : 17)
 
 // ── Loader-specific configuration ────────────────────────────────────────────
 if (isNeoForge) {
@@ -96,7 +98,8 @@ if (isNeoForge) {
     dependencies {
         implementation "net.neoforged:neoforge:${neo_version}"
         if (project.hasProperty('geckolib_version')) {
-            implementation "software.bernie.geckolib:geckolib-neoforge-${minecraft_version}:${geckolib_version}"
+            def geckolibGroup = mcMajor >= 26 ? 'com.geckolib' : 'software.bernie.geckolib'
+            implementation "${geckolibGroup}:geckolib-neoforge-${minecraft_version}:${geckolib_version}"
         }
         if (jei_version != 'none') {
             compileOnly "mezz.jei:jei-${minecraft_version}-neoforge-api:${jei_version}"

--- a/versions/26.1-neoforge/gradle.properties
+++ b/versions/26.1-neoforge/gradle.properties
@@ -1,0 +1,4 @@
+minecraft_version=26.1
+neo_version=26.1.0.8-beta
+jei_version=29.2.0
+geckolib_version=5.5


### PR DESCRIPTION
## Summary
This PR adds support for Minecraft 26.x with NeoForge, including necessary build configuration updates to handle the new major version and its Java 25 requirement.

## Key Changes
- **Version parsing**: Added `mcMajor` variable to parse the major Minecraft version for more robust version comparisons
- **Item properties constant**: Updated `has_item_props` check to account for NeoForge 26.x+ versions where ItemProperties were removed
- **Java toolchain**: Updated Java version selection logic to require Java 25 for NeoForge 26.x, while maintaining Java 21 for earlier NeoForge versions and newer Forge versions
- **GeckoLib dependency**: Added conditional logic to use the new `com.geckolib` group ID for Minecraft 26.x+ instead of the legacy `software.bernie.geckolib` group
- **Version configuration**: Added new `versions/26.1-neoforge/gradle.properties` with appropriate dependency versions for Minecraft 26.1

## Notable Implementation Details
- The `mcMajor` variable enables cleaner version comparisons for major version boundaries
- GeckoLib group ID selection is based on major version to accommodate the library's reorganization in newer versions
- Java version selection uses a ternary chain prioritizing Java 25 for NeoForge 26.x, then Java 21 for other modern versions, falling back to Java 17 for older versions

https://claude.ai/code/session_01LaBjyAUtAbLiaewY4Q8zHJ