### PR TITLE
Disable JEI dependency for NeoForge 26.1

### DIFF
--- a/versions/26.1-neoforge/gradle.properties
+++ b/versions/26.1-neoforge/gradle.properties
@@ -1,4 +1,4 @@
 minecraft_version=26.1
 neo_version=26.1.0.8-beta
-jei_version=29.2.0
+jei_version=none
 geckolib_version=5.5


### PR DESCRIPTION
## Summary
This change disables the JEI (Just Enough Items) dependency for the NeoForge 26.1 version by setting the version to "none".

## Changes
- Updated `jei_version` from `29.2.0` to `none` in the NeoForge 26.1 gradle properties file

## Details
This modification prevents JEI from being included as a dependency in the NeoForge 26.1 build configuration. This may be due to compatibility issues, build conflicts, or a deliberate decision to remove the optional dependency from this version.

https://claude.ai/code/session_01L2Vn32FQqhq56kGmMy7hZX